### PR TITLE
Add missing terms in Bose Hubbard hamiltonian

### DIFF
--- a/src/models/hamiltonians.jl
+++ b/src/models/hamiltonians.jl
@@ -298,8 +298,13 @@ function bose_hubbard_model(elt::Type{<:Number}=ComplexF64,
     N = a_number(elt, symmetry; cutoff=cutoff)
     interaction_term = contract_onesite(N, N - id(domain(N)))
 
-    H = @mpoham sum(nearest_neighbours(lattice)) do (i, j)
-        return -t * hopping_term{i,j} + U / 2 * interaction_term{i} - mu * N{i}
+    H = @mpoham begin
+        sum(nearest_neighbours(lattice)) do (i, j)
+            return -t * hopping_term{i,j}
+        end +
+        sum(vertices(lattice)) do i
+            return U / 2 * interaction_term{i} - mu * N{i}
+        end
     end
 
     if symmetry === Trivial


### PR DESCRIPTION
Current implementation runs through nearest neighbor pairs of the lattice and constructs the interaction and chemical potential terms. However, this does not take into account the contributions of the last lattice site when using a FiniteChain lattice. 

The other models have already been implemented correctly by running through the vertices of the lattice instead. This PR fixes the Bose-Hubbard Hamiltonian which seems to have been left out.