### PR TITLE
Docs additions

### DIFF
--- a/docs/src/man/operators.md
+++ b/docs/src/man/operators.md
@@ -14,11 +14,13 @@ The special keyword argument `side` can be used for operators that require an ad
 
 ## Spin operators
 
-The spin operators `S_x`, `S_y` and `S_z` are defined such that they obey the spin commutation relations ``[Sⱼ, Sₖ] = i ɛⱼₖₗ Sₗ``.
-Additionally, the ladder operators are defined as ``S± = Sˣ ± i Sʸ``.
+The spin operators `S_x`, `S_y` and `S_z` are defined such that they obey the spin commutation relations ``[S^j, S^k] = i \varepsilon_{jkl} S^l``.
+Additionally, the ladder operators are defined as ``S^{\pm} = S^x \pm i S^y``.
 Several combinations are defined that act on two spins.
 
-When imposing symmetries, by convention we choose `S_z` as the diagonal operator for U₁, and `S_x` as the diagonal operator for ℤ₂.
+Supported values of `symmetry` for spin operators are `Trivial`, `Z2Irrep` and `U1Irrep`. 
+When imposing symmetries, by convention we choose `S_z` as the diagonal operator for
+``\mathrm{U}(1)``, and `S_x` as the diagonal operator for ``\mathbb{Z}_2``.
 
 ```@docs
 S_x
@@ -52,21 +54,23 @@ For convenience, the Pauli matrices can also be recovered as ``σⁱ = 2 Sⁱ``.
 
 ## Bosonic operators
 
-The bosonic creation and annihilation operators `a_plus` ($$a^\dagger$$) and `a_min` ($$a$$) are defined such that the following holds:
+The bosonic creation and annihilation operators `a_plus` ($$a^+$$) and `a_min` ($$a^-$$) are defined such that the following holds:
 
-$$a^\dagger \left|n\right> = \sqrt(n + 1) \left|n+1\right>$$
-$$a \left|n\right> = \sqrt(n) \left|n-1\right>$$
+$$a^+ \left|n\right> = \sqrt{n + 1} \left|n+1\right>$$
+$$a^- \left|n\right> = \sqrt{n} \left|n-1\right>$$
 
-From these, a number operator ``a_number`` ($$N$$) can be defined:
+From these, a number operator `a_number` ($$N$$) can be defined:
 
-$$N = a^\dagger a$$
+$$N = a^+ a^-$$
 $$N\left|n\right> = n \left|n\right>$$
 
 With these, the following commutators can be obtained:
 
-$$\left[a, a^\dagger\right] = 1$$
-$$\left[N,a^\dagger\right] = a^\dagger$$
-$$\left[N,a\right] = -a$$
+$$\left[a^-, a^+\right] = 1$$
+$$\left[N, a^+\right] = a^+$$
+$$\left[N, a^-\right] = -a^-$$
+
+Supported values of `symmetry` for bosonic operators are `Trivial` and `U1Irrep`.
 
 ```@docs
 a_plus
@@ -76,10 +80,17 @@ a_number
 
 ## Fermionic operators
 
+Spinless fermions.
+
 ```@docs
 c_plus
 c_min
 c_number
+```
+
+Spinful fermions.
+
+```@docs
 e_plus
 e_min
 e_number

--- a/src/MPSKitModels.jl
+++ b/src/MPSKitModels.jl
@@ -23,6 +23,7 @@ export spinmatrices, nonsym_spintensors, nonsym_bosonictensors
 
 export S_x, S_y, S_z, S_plus, S_min
 export S_xx, S_yy, S_zz, S_plusmin, S_minplus, S_exchange
+export Sˣ, Sʸ, Sᶻ, S⁺, S⁻, Sˣˣ, Sʸʸ, Sᶻᶻ, S⁺⁻, S⁻⁺, SS
 export σˣ, σʸ, σᶻ, σ⁺, σ⁻, σˣˣ, σʸʸ, σᶻᶻ, σ⁺⁻, σ⁻⁺, σσ
 
 export a_plus, a_min, a_plusmin, a_minplus, a_number

--- a/src/models/quantum_chemistry.jl
+++ b/src/models/quantum_chemistry.jl
@@ -15,11 +15,13 @@ Base.:*(_, ::EmptyVal) = EmptyVal()
 """
     quantum_chemistry_hamiltonian(E0::Number, K::AbstractMatrix{<:Number}, V::AbstractArray{<:Number,4}, [elt::Type{<:Number}=ComplexF64])
 
-MPO for the quantum chemistry Hamiltonian, with kinetic energy K and potential energy V. The Hamiltonian is given by
+MPO for the quantum chemistry Hamiltonian, with kinetic energy ``K`` and potential energy ``V``. The Hamiltonian is given by
+
 ```math
-H = E0 + ∑ᵢⱼ ∑ₛ K[i,j] c^{s,+}_i c^{s,-}_j + ∑ᵢⱼₖₗ ∑ₛₜ V[i,j,k,l] c^{s,+}_i c^{t,+}_j c^{t,-}_k c^{s,-}_l
+H = E0 + \\sum_{i,j} \\sum_s K[i,j] e_{i,s}^{+} e_{j,s}^{-} + \\sum_{i,j,k,l} \\sum_{s,t} V[i,j,k,l] e_{i,s}^{+} e_{j,t}^{+} e_{k,t}^{-} e_{l,s}^{-}
 ```
-where `s` and `t` are spin indices, which can be `↑` or `↓`. The full hamiltonian has U₁ × SU₂ × FermionParity symmetry.
+
+where ``s`` and ``t`` are spin indices, which can be ``\\uparrow`` or ``\\downarrow``. The full hamiltonian has `U₁ ⊠ SU₂ ⊠ FermionParity` symmetry.
 
 !!! note
     This should not be regarded as state-of-the-art quantum chemistry DMRG code. It is only meant to demonstrate the use of MPSKit for quantum chemistry. In particular:

--- a/src/models/transfermatrices.jl
+++ b/src/models/transfermatrices.jl
@@ -5,9 +5,13 @@
     classical_ising([elt::Type{<:Number}=ComplexF64], [symmetry::Type{<:Sector}=Trivial];
                     beta=log(1+sqrt(2))/2)
 
-MPO for the classical Ising partition function, defined by
-    
-``Z(β) = ∑_s exp(-βH(s))`` with ``H(s) = ∑_{<i,j>}σ_i σ_j``
+MPO for the partition function of the two-dimensional classical Ising model, defined as
+
+```math
+\\mathcal{Z}(\\beta) = \\sum_{\\{s\\}} \\exp(-\\beta H(s)) \\text{ with } H(s) = \\sum_{\\langle i, j \\rangle} s_i s_j
+
+```
+where each classical spin can take the values ``s = \\pm 1``.
 """
 function classical_ising end
 function classical_ising(symmetry::Type{<:Sector}; kwargs...)
@@ -49,7 +53,7 @@ end
     sixvertex([elt::Type{<:Number}=ComplexF64], [symmetry::Type{<:Sector}=Trivial];
               a=1.0, b=1.0, c=1.0)
 
-MPO for the six vertex model.
+MPO for the partition function of the two-dimensional six vertex model.
 """
 function sixvertex end
 sixvertex(symmetry::Type{<:Sector}; kwargs...) = sixvertex(ComplexF64, symmetry; kwargs...)
@@ -85,7 +89,7 @@ end
 """
     hard_hexagon([elt::Type{<:Number}=ComplexF64])
 
-MPO for the hard hexagon model.
+MPO for the partition function of the two-dimensional hard hexagon model.
 """
 function hard_hexagon(elt::Type{<:Number}=ComplexF64)
     P = Vect[FibonacciAnyon](:τ => 1)
@@ -101,7 +105,7 @@ end
 """
     qstate_clock([elt::Type{<:Number}=ComplexF64], [symmetry::Type{<:Sector}=Trivial]; beta::Number=1.0, q::Integer=3)
 
-MPO for the discrete clock model with ``q`` states.
+MPO for the partition function of the two-dimensional discrete clock model with ``q`` states.
 """
 function qstate_clock(elt::Type{<:Number}=ComplexF64, ::Type{Trivial}=Trivial;
                       beta::Number=1.0, q::Integer=3)

--- a/src/operators/bosonoperators.jl
+++ b/src/operators/bosonoperators.jl
@@ -1,5 +1,6 @@
 """
     a_plus([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff=5)
+    a⁺([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff=5)
 
 The truncated bosonic creation operator, with a maximum of `cutoff` bosons per site.
 """
@@ -46,6 +47,7 @@ const a⁺ = a_plus
 
 """
     a_min([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff=5)
+    a⁻([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; cutoff=5)    
 
 The truncated bosonic annihilation operator, with a maximum of `cutoff` bosons per site.
 """

--- a/src/operators/fermionoperators.jl
+++ b/src/operators/fermionoperators.jl
@@ -4,8 +4,9 @@
 
 """
     c_plus([elt::Type{<:Number}=ComplexF64]; side=:L)
+    c⁺([elt::Type{<:Number}=ComplexF64]; side=:L)
 
-fermionic creation operator.
+Fermionic creation operator.
 """
 function c_plus(elt::Type{<:Number}=ComplexF64; side=:L)
     vspace = Vect[fℤ₂](1 => 1)
@@ -26,8 +27,9 @@ const c⁺ = c_plus
 
 """
     c_min([elt::Type{<:Number}=ComplexF64]; side=:L)
+    c⁻([elt::Type{<:Number}=ComplexF64]; side=:L)
 
-fermionic annihilation operator.
+Fermionic annihilation operator.
 """
 function c_min(elt::Type{<:Number}=ComplexF64; side=:L)
     if side === :L
@@ -56,7 +58,7 @@ const c⁻c⁻ = c_minmin
 """
     c_number([elt::Type{<:Number}=ComplexF64])
 
-fermionic number operator.
+Fermionic number operator.
 """
 function c_number(elt::Type{<:Number}=ComplexF64)
     pspace = Vect[fℤ₂](0 => 1, 1 => 1)
@@ -71,6 +73,7 @@ end
 
 """
     e_plus([elt::Type{<:Number}=ComplexF64], particle_symmetry, spin_symmetry; side=:L)
+    e⁺([elt::Type{<:Number}=ComplexF64], particle_symmetry, spin_symmetry; side=:L)
 
 The creation operator for electron-like fermions.
 """
@@ -116,6 +119,7 @@ const e⁺ = e_plus
 
 """
     e_min([elt::Type{<:Number}=ComplexF64], particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; side=:L)
+    e⁻([elt::Type{<:Number}=ComplexF64], particle_symmetry::Type{<:Sector}, spin_symmetry::Type{<:Sector}; side=:L)
 
 The annihilation operator for electron-like fermions.
 """

--- a/src/operators/spinoperators.jl
+++ b/src/operators/spinoperators.jl
@@ -350,7 +350,8 @@ const S⁻ = S_min
 
 unicode_table = Dict(:x => :ˣ, :y => :ʸ, :z => :ᶻ, :plus => :⁺, :min => :⁻)
 
-spinop_docstring(L::Symbol, R::Symbol) = """
+function spinop_docstring(L::Symbol, R::Symbol)
+    return """
     S_$L$R([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
     $(Symbol(:S, unicode_table[L], unicode_table[R]))([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
 
@@ -358,6 +359,7 @@ The spin $L$R exchange operator.
 
 See also [`σ$(unicode_table[L])$(unicode_table[R])`](@ref)
 """
+end
 function pauli_unicode_docstring(L::Symbol, R::Symbol)
     return """Pauli $L$R operator."""
 end

--- a/src/operators/spinoperators.jl
+++ b/src/operators/spinoperators.jl
@@ -46,6 +46,7 @@ end
 
 """
     S_x([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
+    Sˣ([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
 
 The spin operator along the x-axis.
 
@@ -96,11 +97,14 @@ function S_x(elt::Type{<:Number}, ::Type{U1Irrep}; spin=1 // 2, side=:L)
     return X
 end
 
-"""Pauli x operator"""
+const Sˣ = S_x
+
+"""Pauli x operator."""
 σˣ(args...; kwargs...) = 2 * S_x(args...; kwargs...)
 
 """
     S_y([eltype::Type{<:Complex}], [symmetry::Type{<:Sector}]; spin=1 // 2)
+    Sʸ([eltype::Type{<:Complex}], [symmetry::Type{<:Sector}]; spin=1 // 2)
 
 The spin operator along the y-axis.
 
@@ -164,13 +168,17 @@ function S_y(elt::Type{<:Complex}, ::Type{U1Irrep}; spin=1 // 2, side=:L)
     return Y
 end
 
-"""Pauli y operator"""
+const Sʸ = S_y
+
+"""Pauli y operator."""
 σʸ(args...; kwargs...) = 2 * S_y(args...; kwargs...)
 
 """
     S_z([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
+    Sᶻ([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
 
-The spin operator along the z-axis.
+The spin operator along the z-axis. Possible values for `symmetry` are `Trivial`, `Z2Irrep`,
+and `U1Irrep`.
 
 See also [`σᶻ`](@ref)
 """
@@ -213,11 +221,14 @@ function S_z(elt::Type{<:Number}, ::Type{U1Irrep}; spin=1 // 2)
     return Z
 end
 
-"""Pauli z operator"""
+const Sᶻ = S_z
+
+"""Pauli z operator."""
 σᶻ(args...; kwargs...) = 2 * S_z(args...; kwargs...)
 
 """
     S_plus([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
+    S⁺([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
 
 The spin plus operator.
 
@@ -271,11 +282,14 @@ function S_plus(elt::Type{<:Number}, ::Type{U1Irrep}; spin=1 // 2, side=:L)
     return S⁺
 end
 
-"""Pauli plus operator"""
+const S⁺ = S_plus
+
+"""Pauli plus operator."""
 σ⁺(args...; kwargs...) = 2 * S_plus(args...; kwargs...)
 
 """
     S_min([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
+    S⁻([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
 
 The spin minus operator.
 
@@ -329,29 +343,33 @@ function S_min(elt::Type{<:Number}, ::Type{U1Irrep}; spin=1 // 2, side=:L)
     return S⁻
 end
 
-"""Pauli minus operator"""
+const S⁻ = S_min
+
+"""Pauli minus operator."""
 σ⁻(args...; kwargs...) = 2 * S_min(args...; kwargs...)
 
 unicode_table = Dict(:x => :ˣ, :y => :ʸ, :z => :ᶻ, :plus => :⁺, :min => :⁻)
 
-pauli_docstring(L::Symbol, R::Symbol) = """
+spinop_docstring(L::Symbol, R::Symbol) = """
     S_$L$R([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
+    $(Symbol(:S, unicode_table[L], unicode_table[R]))([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
 
 The spin $L$R exchange operator.
 
 See also [`σ$(unicode_table[L])$(unicode_table[R])`](@ref)
 """
 function pauli_unicode_docstring(L::Symbol, R::Symbol)
-    return """Pauli $L$R operator"""
+    return """Pauli $L$R operator."""
 end
 
 for (L, R) in ((:x, :x), (:y, :y), (:z, :z), (:plus, :min), (:min, :plus))
     f = Symbol(:S_, L, R)
     fₗ = Symbol(:S_, L)
     fᵣ = Symbol(:S_, R)
-    f_unicode = Symbol(:σ, unicode_table[L], unicode_table[R])
-    docstring = pauli_docstring(L, R)
-    unicode_docstring = pauli_unicode_docstring(L, R)
+    f_unicode = Symbol(:S, unicode_table[L], unicode_table[R])
+    f_pauli = Symbol(:σ, unicode_table[L], unicode_table[R])
+    docstring = spinop_docstring(L, R)
+    pauli_docstring = pauli_unicode_docstring(L, R)
     @eval MPSKitModels begin
         @doc $docstring $f
         ($f)(; kwargs...) = ($f)(ComplexF64, Trivial; kwargs...)
@@ -368,7 +386,9 @@ for (L, R) in ((:x, :x), (:y, :y), (:z, :z), (:plus, :min), (:min, :plus))
                                     $(fᵣ)(elt, symmetry; spin=spin, side=:R))
         end
 
-        @doc $unicode_docstring function $f_unicode(args...; kwargs...)
+        const $f_unicode = $f
+
+        @doc $pauli_docstring function $f_pauli(args...; kwargs...)
             return 4 * ($f)(args...; kwargs...)
         end
     end
@@ -383,6 +403,7 @@ end
 
 """
     S_exchange([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
+    SS([eltype::Type{<:Number}], [symmetry::Type{<:Sector}]; spin=1 // 2)
 
 The spin exchange operator.
 
@@ -417,5 +438,7 @@ function S_exchange(elt::Type{<:Number}, symmetry::Type{<:Sector}; spin=1 // 2)
            S_zz(elt, symmetry; spin=spin)
 end
 
-"""Pauli exchange operator"""
+const SS = S_exchange
+
+"""Pauli exchange operator."""
 σσ(args...; kwargs...) = 4 * S_exchange(args...; kwargs...)

--- a/test/tfim.jl
+++ b/test/tfim.jl
@@ -29,3 +29,7 @@ end
     ψ, envs, δ = find_groundstate(ψ₀, H, alg)
     @test E₀ ≈ sum(expectation_value(ψ, H, envs)) atol = 1e-3
 end
+
+@testset "illegal symmetry" begin
+    @test_throws ArgumentError transverse_field_ising(U1Irrep)
+end


### PR DESCRIPTION
An attempt at improving consistency in spin and Pauli operator naming between the implementation and the documentation that got a little out of hand. Tried to:
- Systematically use `Sⁱ` for spin operators in model Hamiltonian docstrings. In particular, also introduced unicode aliases for these to be consistent with the model docstrings.
- Systematically use `a⁺` and `a⁻` for bosonic creation operators, both in the definitions in the documentation and in the model Hamiltonian docstrings.
- Systematically use `e` for spinful fermions.
- Explicitly add all unicode aliases to the docstrings.

I think all of the spinful fermion operators that take an up-down spin index also need an explicit docstring to be able to make sense of the Hubbard Hamiltonian, but I didn't try this (yet) since I'm not too sure about what's going on exactly.