### PR TITLE
update quantum chemistry Hamiltonian

### DIFF
--- a/src/MPSKitModels.jl
+++ b/src/MPSKitModels.jl
@@ -2,7 +2,7 @@ module MPSKitModels
 
 using TensorKit, MPSKit
 using MacroTools: @capture, postwalk
-using MPSKit: @plansor
+using MPSKit: @plansor, add_util_leg
 using TensorOperations
 using TupleTools
 

--- a/src/models/quantum_chemistry.jl
+++ b/src/models/quantum_chemistry.jl
@@ -813,7 +813,7 @@ function mapped_quantum_chemistry_hamiltonian(E0, K, V, Elt = ComplexF64)
     # remove last site terms that only propagate with right
     v[end] = v[end][:, end:end]
 
-    # TODO constructor errors: edges should have single level
+    # TODO constructor errors: space mismatch
     th = FiniteMPOHamiltonian(v)
 
     return th + fill(Elt(E0) / basis_size, basis_size),

--- a/src/models/quantum_chemistry.jl
+++ b/src/models/quantum_chemistry.jl
@@ -808,6 +808,11 @@ function mapped_quantum_chemistry_hamiltonian(E0, K, V, Elt = ComplexF64)
     map!(x -> x == EmptyVal() ? Elt(0) : x, hamdat, hamdat)
     v = convert.(Matrix{Union{Elt, typeof(ut_ap)}}, eachslice(hamdat; dims = 1))
 
+    # remove first site terms that only propagate with left
+    v[begin] = v[begin][begin:begin, :]
+    # remove last site terms that only propagate with right
+    v[end] = v[end][:, end:end]
+
     # TODO constructor errors: edges should have single level
     th = FiniteMPOHamiltonian(v)
 

--- a/src/models/quantum_chemistry.jl
+++ b/src/models/quantum_chemistry.jl
@@ -1,616 +1,807 @@
-struct EmptyVal end
-
-Base.:+(::EmptyVal, ::EmptyVal) = EmptyVal();
-Base.:+(::EmptyVal, v) = v
-Base.:+(v, ::EmptyVal) = v
-
-Base.:-(::EmptyVal, ::EmptyVal) = EmptyVal();
-Base.:-(::EmptyVal, v) = -v
-Base.:-(v, ::EmptyVal) = v
-
-Base.:*(::EmptyVal, ::EmptyVal) = EmptyVal()
-Base.:*(::EmptyVal, _) = EmptyVal()
-Base.:*(_, ::EmptyVal) = EmptyVal()
-
-"""
-    quantum_chemistry_hamiltonian(E0::Number, K::AbstractMatrix{<:Number}, V::AbstractArray{<:Number,4}, [elt::Type{<:Number}=ComplexF64])
-
-MPO for the quantum chemistry Hamiltonian, with kinetic energy ``K`` and potential energy ``V``. The Hamiltonian is given by
-
-```math
-H = E0 + \\sum_{i,j} \\sum_s K[i,j] e_{i,s}^{+} e_{j,s}^{-} + \\sum_{i,j,k,l} \\sum_{s,t} V[i,j,k,l] e_{i,s}^{+} e_{j,t}^{+} e_{k,t}^{-} e_{l,s}^{-}
-```
-
-where ``s`` and ``t`` are spin indices, which can be ``\\uparrow`` or ``\\downarrow``. The full hamiltonian has `U₁ ⊠ SU₂ ⊠ FermionParity` symmetry.
-
-!!! note
-    This should not be regarded as state-of-the-art quantum chemistry DMRG code. It is only meant to demonstrate the use of MPSKit for quantum chemistry. In particular:
-    - No attempt was made to incorporate spacegroup symmetries
-    - MPSKit does not contain many required algorithms in quantum chemistry (orbital ordering/optimization)
-    - MPOHamiltonian is not well suited for quantum chemistry
-"""
-function quantum_chemistry_hamiltonian(E0, K, V, Elt = ComplexF64)
-    return mapped_quantum_chemistry_hamiltonian(E0, K, V, Elt)[1]
+struct EmptyVal
 end
 
-function mapped_quantum_chemistry_hamiltonian(E0, K, V, Elt = ComplexF64)
-    basis_size = size(K, 1)
-    half_basis_size = Int(ceil(basis_size / 2))
+Base.:+(::EmptyVal,::EmptyVal) = EmptyVal();
+Base.:+(::EmptyVal,v) = v
+Base.:+(v,::EmptyVal) = v
 
+Base.:-(::EmptyVal,::EmptyVal) = EmptyVal();
+Base.:-(::EmptyVal,v) = -v
+Base.:-(v,::EmptyVal) = v
+
+
+Base.:*(::EmptyVal,::EmptyVal) = EmptyVal()
+Base.:*(::EmptyVal,_) = EmptyVal()
+Base.:*(_,::EmptyVal) = EmptyVal()
+"""
+    Implements
+    
+    H = E0 + ∑ᵢⱼ ∑ₛ K[i,j] c^{s,+}_i c^{s,-}_j + ∑ᵢⱼₖₗ ∑ₛₜ V[i,j,k,l] c^{s,+}_i c^{t,+}_j c^{t,-}_k c^{s,-}_l
+
+    where s and t are spin indices, which can be up or down. The full hamiltonian has U₁ × SU₂ × FermionParity symmetry.
+
+    This should not be regarded as a state of the art qchem-dmrg code! 
+        - No attempt was made to incorporate spacegroup symmetries
+        - MPSKit does not contain many required algorithms in qchem (orbital ordering/optimization)
+        - MPOHamiltonian is not well suited for quantum chemistry
+"""
+quantum_chemistry_hamiltonian(E0,K,V,Elt=ComplexF64) = mapped_quantum_chemistry_hamiltonian(E0,K,V,Elt)[1]
+
+function mapped_quantum_chemistry_hamiltonian(E0,K,V,Elt=ComplexF64)
+    basis_size = size(K,1);
+    half_basis_size = Int(ceil(basis_size/2));
+    
     # the phsyical space
-    psp = Vect[(Irrep[U₁] ⊠ Irrep[SU₂] ⊠ FermionParity)](
-        (0, 0, 0) => 1,
-        (1, 1 // 2, 1) => 1,
-        (2, 0, 0) => 1
-    )
+    psp = Vect[(Irrep[U₁]⊠Irrep[SU₂] ⊠ FermionParity)]((0,0,0)=>1, (1,1//2,1)=>1, (2,0,0)=>1);
 
-    ap = TensorMap(
-        ones, Elt,
-        psp * Vect[(Irrep[U₁] ⊠ Irrep[SU₂] ⊠ FermionParity)]((-1, 1 // 2, 1) => 1),
-        psp
-    )
-    blocks(ap)[(U₁(0) ⊠ SU₂(0) ⊠ FermionParity(0))] .*= -sqrt(2)
-    blocks(ap)[(U₁(1) ⊠ SU₂(1 // 2) ⊠ FermionParity(1))] .*= 1
+    ap = TensorMap(ones,Elt,psp*Vect[(Irrep[U₁]⊠Irrep[SU₂] ⊠ FermionParity)]((-1,1//2,1)=>1),psp);
+    blocks(ap)[(U₁(0)⊠SU₂(0)⊠FermionParity(0))] .*= -sqrt(2);
+    blocks(ap)[(U₁(1)⊠SU₂(1//2)⊠FermionParity(1))]  .*= 1;
 
-    bm = TensorMap(
-        ones, Elt, psp,
-        Vect[(Irrep[U₁] ⊠ Irrep[SU₂] ⊠ FermionParity)]((-1, 1 // 2, 1) => 1) * psp
-    )
-    blocks(bm)[(U₁(0) ⊠ SU₂(0) ⊠ FermionParity(0))] .*= sqrt(2)
-    blocks(bm)[(U₁(1) ⊠ SU₂(1 // 2) ⊠ FermionParity(1))] .*= -1
+
+    bm = TensorMap(ones,Elt,psp,Vect[(Irrep[U₁]⊠Irrep[SU₂]⊠FermionParity)]((-1,1//2,1)=>1)*psp);
+    blocks(bm)[(U₁(0)⊠SU₂(0)⊠FermionParity(0))] .*= sqrt(2);
+    blocks(bm)[(U₁(1)⊠SU₂(1//2)⊠FermionParity(1))] .*= -1;
 
     # this transposition is easier to reason about in a planar way
-    am = transpose(ap', (2, 1), (3,))
-    bp = transpose(bm', (1,), (3, 2))
-    ap = transpose(ap, (3, 1), (2,))
-    bm = transpose(bm, (2,), (3, 1))
+    am = transpose(ap',(2,1),(3,));
+    bp = transpose(bm',(1,),(3,2));
+    ap = transpose(ap,(3,1),(2,));
+    bm = transpose(bm,(2,),(3,1));
+    
+    @plansor b_derp[-1 -2;-3] := bp[1;2 -2]*τ[-3 -1;2 1]
+    Lmap_ap_to_bp = inv(ap'*ap)*ap'*b_derp;
+    @assert norm(ap*Lmap_ap_to_bp-b_derp) < 1e-12;
+    @plansor b_derp[-1 -2;-3] := bm[1;2 -2]*τ[-3 -1;2 1]
+    Lmap_am_to_bm = inv(am'*am)*am'*b_derp;
+    @assert norm(am*Lmap_am_to_bm-b_derp) < 1e-12;
 
-    @plansor b_derp[-1 -2; -3] := bp[1; 2 -2] * τ[-3 -1; 2 1]
-    Lmap_ap_to_bp = inv(ap' * ap) * ap' * b_derp
-    @assert norm(ap * Lmap_ap_to_bp - b_derp) < 1.0e-12
-    @plansor b_derp[-1 -2; -3] := bm[1; 2 -2] * τ[-3 -1; 2 1]
-    Lmap_am_to_bm = inv(am' * am) * am' * b_derp
-    @assert norm(am * Lmap_am_to_bm - b_derp) < 1.0e-12
+    Rmap_bp_to_ap = transpose(Lmap_am_to_bm',(2,),(1,));
+    Rmap_bm_to_am = transpose(Lmap_ap_to_bp',(2,),(1,));
+    @plansor a_derp[-1 -2;-3] := bp[1;-1 2]*Rmap_bp_to_ap[1;3]*τ[2 3;-3 -2]
+    @assert norm(a_derp-ap) < 1e-12
+    @plansor a_derp[-1 -2;-3] := bm[1;-1 2]*Rmap_bm_to_am[1;3]*τ[2 3;-3 -2]
+    @assert norm(a_derp-am) < 1e-12
 
-    Rmap_bp_to_ap = transpose(Lmap_am_to_bm', (2,), (1,))
-    Rmap_bm_to_am = transpose(Lmap_ap_to_bp', (2,), (1,))
-    @plansor a_derp[-1 -2; -3] := bp[1; -1 2] * Rmap_bp_to_ap[1; 3] * τ[2 3; -3 -2]
-    @assert norm(a_derp - ap) < 1.0e-12
-    @plansor a_derp[-1 -2; -3] := bm[1; -1 2] * Rmap_bm_to_am[1; 3] * τ[2 3; -3 -2]
-    @assert norm(a_derp - am) < 1.0e-12
+    h_pm = TensorMap(ones,Elt,psp,psp);
+    blocks(h_pm)[(U₁(0)⊠SU₂(0)⊠ FermionParity(0))] .=0;
+    blocks(h_pm)[(U₁(1)⊠SU₂(1//2)⊠ FermionParity(1))] .=1;
+    blocks(h_pm)[(U₁(2)⊠SU₂(0)⊠ FermionParity(0))] .=2;
 
-    h_pm = TensorMap(ones, Elt, psp, psp)
-    blocks(h_pm)[(U₁(0) ⊠ SU₂(0) ⊠ FermionParity(0))] .= 0
-    blocks(h_pm)[(U₁(1) ⊠ SU₂(1 // 2) ⊠ FermionParity(1))] .= 1
-    blocks(h_pm)[(U₁(2) ⊠ SU₂(0) ⊠ FermionParity(0))] .= 2
+    @plansor o_derp[-1 -2;-3 -4] := am[-1 1;-3]*ap[1 -2;-4]
+    h_pm_derp = transpose(h_pm,(2,1),());
+    Lmap_apam_to_pm = inv(o_derp'*o_derp)*o_derp'*h_pm_derp;
+    @assert norm(o_derp*Lmap_apam_to_pm-h_pm_derp) <1e-12;
 
-    @plansor o_derp[-1 -2; -3 -4] := am[-1 1; -3] * ap[1 -2; -4]
-    h_pm_derp = transpose(h_pm, (2, 1), ())
-    Lmap_apam_to_pm = inv(o_derp' * o_derp) * o_derp' * h_pm_derp
-    @assert norm(o_derp * Lmap_apam_to_pm - h_pm_derp) < 1.0e-12
+    @plansor o_derp[-1 -2;-3 -4] := bm[-1;-3 1]*bp[-2;1 -4]
+    h_pm_derp2 = transpose(h_pm,(),(2,1));
+    Rmap_bpbm_to_pm = h_pm_derp2*o_derp'*inv(o_derp*o_derp');
+    @assert norm(transpose(h_pm,(),(2,1))-Rmap_bpbm_to_pm*o_derp) < 1e-12
+    
+    h_ppmm = h_pm*h_pm-h_pm;
 
-    @plansor o_derp[-1 -2; -3 -4] := bm[-1; -3 1] * bp[-2; 1 -4]
-    h_pm_derp2 = transpose(h_pm, (), (2, 1))
-    Rmap_bpbm_to_pm = h_pm_derp2 * o_derp' * inv(o_derp * o_derp')
-    @assert norm(transpose(h_pm, (), (2, 1)) - Rmap_bpbm_to_pm * o_derp) < 1.0e-12
-
-    h_ppmm = h_pm * h_pm - h_pm
-
-    ai = isomorphism(storagetype(ap), psp, psp)
+    ai = isomorphism(storagetype(ap),psp,psp);
     # ----------------------------------------------------------------------
     # Maps something easier to understand to the corresponding virtual index
     # ----------------------------------------------------------------------
 
-    cnt = 1
-    indmap_1L = fill(0, 2, basis_size)
+    cnt = 1;
+    indmap_1L = fill(0,2,basis_size);
     for i in 1:2, j in 1:basis_size
         cnt += 1
-        indmap_1L[i, j] = cnt
+        indmap_1L[i,j] = cnt;
     end
 
-    indmap_1R = fill(0, 2, basis_size)
+    indmap_1R = fill(0,2,basis_size);
     for i in 1:2, j in 1:basis_size
         cnt += 1
-        indmap_1R[i, j] = cnt
+        indmap_1R[i,j] = cnt;
     end
 
-    indmap_2L = fill(0, 2, basis_size, 2, basis_size)
-    indmap_2R = fill(0, 2, basis_size, 2, basis_size)
+    indmap_2L = fill(0,2,basis_size,2,basis_size);
+    indmap_2R = fill(0,2,basis_size,2,basis_size);
     for pm1 in 1:2, i in 1:half_basis_size, pm2 in 1:2, j in i:half_basis_size
         cnt += 1
-        indmap_2L[pm1, i, pm2, j] = cnt
-        indmap_2R[pm1, end - j + 1, pm2, end - i + 1] = cnt
+        indmap_2L[pm1,i,pm2,j] = cnt;
+        indmap_2R[pm1,end-j+1,pm2,end-i+1] = cnt
     end
-
-    hamdat = convert(Array{Any, 3}, fill(EmptyVal(), basis_size, cnt + 1, cnt + 1)) #Array{Any,3}(missing,basis_size,cnt+2,cnt+2);
-    hamdat[:, 1, 1] .+= Elt(1)
-    hamdat[:, end, end] .+= Elt(1)
-
+    
+    hamdat = convert(Array{Any,3},fill(EmptyVal(),basis_size,cnt+1,cnt+1));#Array{Any,3}(missing,basis_size,cnt+2,cnt+2);
+    hamdat[:,1,1].+= Elt(1);
+    hamdat[:,end,end].+= Elt(1);
+    
     # pure onsite interactions:
     for i in 1:basis_size
         # onsite kinetic part
-        hamdat[i, 1, end] += K[i, i] * add_util_leg(h_pm)
+        hamdat[i,1,end] += K[i,i]*add_util_leg(h_pm);
 
         # onsite electronic part
-        hamdat[i, 1, end] += V[i, i, i, i] * add_util_leg(h_ppmm)
+        hamdat[i,1,end] += V[i,i,i,i]*add_util_leg(h_ppmm);
     end
-
+    
+    
     # fill indmap_1L and indmap_1R
-    ut = Tensor(ones, oneunit(psp))
-    @plansor ut_ap[-1 -2; -3 -4] := ut[-1] * ap[-3 -2; -4]
-    @plansor ut_am[-1 -2; -3 -4] := ut[-1] * am[-3 -2; -4]
-    @plansor bp_ut[-1 -2; -3 -4] := bp[-1; -3 -2] * conj(ut[-4])
-    @plansor bm_ut[-1 -2; -3 -4] := bm[-1; -3 -2] * conj(ut[-4])
+    ut = Tensor(ones,oneunit(psp));
+    @plansor ut_ap[-1 -2;-3 -4] := ut[-1]*ap[-3 -2;-4];
+    @plansor ut_am[-1 -2;-3 -4] := ut[-1]*am[-3 -2;-4];
+    @plansor bp_ut[-1 -2;-3 -4] := bp[-1;-3 -2]*conj(ut[-4]);
+    @plansor bm_ut[-1 -2;-3 -4] := bm[-1;-3 -2]*conj(ut[-4]);
     for i in 1:basis_size
-        hamdat[i, 1, indmap_1L[1, i]] += ut_ap
-        hamdat[i, 1, indmap_1L[2, i]] += ut_am
-
-        hamdat[i, indmap_1R[1, i], end] += bp_ut
-        hamdat[i, indmap_1R[2, i], end] += bm_ut
-
-        for loc in (i + 1):basis_size
-            hamdat[loc, indmap_1L[1, i], indmap_1L[1, i]] = Elt(1)
-            hamdat[loc, indmap_1L[2, i], indmap_1L[2, i]] = Elt(1)
+        hamdat[i,1,indmap_1L[1,i]] += ut_ap;
+        hamdat[i,1,indmap_1L[2,i]] += ut_am;
+        
+        hamdat[i,indmap_1R[1,i],end] += bp_ut
+        hamdat[i,indmap_1R[2,i],end] += bm_ut
+        
+        for loc in i+1:basis_size
+            hamdat[loc,indmap_1L[1,i],indmap_1L[1,i]] = Elt(1)
+            hamdat[loc,indmap_1L[2,i],indmap_1L[2,i]] = Elt(1)
         end
 
-        for loc in 1:(i - 1)
-            hamdat[loc, indmap_1R[1, i], indmap_1R[1, i]] = Elt(1)
-            hamdat[loc, indmap_1R[2, i], indmap_1R[2, i]] = Elt(1)
+        for loc in 1:i-1
+            hamdat[loc,indmap_1R[1,i],indmap_1R[1,i]] = Elt(1)
+            hamdat[loc,indmap_1R[2,i],indmap_1R[2,i]] = Elt(1)
         end
     end
 
     # indmap_2 onsite part
     # we need pp, mm, pm
-    pp_f = isometry(fuse(_lastspace(ap)' * _lastspace(ap)'), _lastspace(ap)' * _lastspace(ap)')
-    mm_f = isometry(fuse(_lastspace(am)' * _lastspace(am)'), _lastspace(am)' * _lastspace(am)')
-    mp_f = isometry(fuse(_lastspace(am)' * _lastspace(ap)'), _lastspace(am)' * _lastspace(ap)')
-    pm_f = isometry(fuse(_lastspace(ap)' * _lastspace(am)'), _lastspace(ap)' * _lastspace(am)')
+    pp_f = isometry(fuse(_lastspace(ap)'*_lastspace(ap)'),_lastspace(ap)'*_lastspace(ap)');
+    mm_f = isometry(fuse(_lastspace(am)'*_lastspace(am)'),_lastspace(am)'*_lastspace(am)');
+    mp_f = isometry(fuse(_lastspace(am)'*_lastspace(ap)'),_lastspace(am)'*_lastspace(ap)');
+    pm_f = isometry(fuse(_lastspace(ap)'*_lastspace(am)'),_lastspace(ap)'*_lastspace(am)');
 
-    @plansor ut_apap[-1 -2; -3 -4] := ut[-1] * ap[-3 1; 3] * ap[1 -2; 4] *
-        conj(pp_f[-4; 3 4])
-    @plansor ut_amam[-1 -2; -3 -4] := ut[-1] * am[-3 1; 3] * am[1 -2; 4] *
-        conj(mm_f[-4; 3 4])
-    @plansor ut_amap[-1 -2; -3 -4] := ut[-1] * am[-3 1; 3] * ap[1 -2; 4] *
-        conj(mp_f[-4; 3 4])
-    @plansor ut_apam[-1 -2; -3 -4] := ut[-1] * ap[-3 1; 3] * am[1 -2; 4] *
-        conj(pm_f[-4; 3 4])
 
-    @plansor bpbp_ut[-1 -2; -3 -4] := mm_f[-1; 1 2] * bp[1; -3 3] * bp[2; 3 -2] *
-        conj(ut[-4])
-    @plansor bmbm_ut[-1 -2; -3 -4] := pp_f[-1; 1 2] * bm[1; -3 3] * bm[2; 3 -2] *
-        conj(ut[-4])
-    @plansor bmbp_ut[-1 -2; -3 -4] := pm_f[-1; 1 2] * bm[1; -3 3] * bp[2; 3 -2] *
-        conj(ut[-4])
-    @plansor bpbm_ut[-1 -2; -3 -4] := mp_f[-1; 1 2] * bp[1; -3 3] * bm[2; 3 -2] *
-        conj(ut[-4])
+    @plansor ut_apap[-1 -2;-3 -4] := ut[-1]*ap[-3 1;3]*ap[1 -2;4]*conj(pp_f[-4;3 4]);
+    @plansor ut_amam[-1 -2;-3 -4] := ut[-1]*am[-3 1;3]*am[1 -2;4]*conj(mm_f[-4;3 4]);
+    @plansor ut_amap[-1 -2;-3 -4] := ut[-1]*am[-3 1;3]*ap[1 -2;4]*conj(mp_f[-4;3 4]);
+    @plansor ut_apam[-1 -2;-3 -4] := ut[-1]*ap[-3 1;3]*am[1 -2;4]*conj(pm_f[-4;3 4]);
 
+    @plansor bpbp_ut[-1 -2;-3 -4] := mm_f[-1;1 2]*bp[1;-3 3]*bp[2;3 -2]*conj(ut[-4]);
+    @plansor bmbm_ut[-1 -2;-3 -4] := pp_f[-1;1 2]*bm[1;-3 3]*bm[2;3 -2]*conj(ut[-4]);
+    @plansor bmbp_ut[-1 -2;-3 -4] := pm_f[-1;1 2]*bm[1;-3 3]*bp[2;3 -2]*conj(ut[-4]);
+    @plansor bpbm_ut[-1 -2;-3 -4] := mp_f[-1;1 2]*bp[1;-3 3]*bm[2;3 -2]*conj(ut[-4]);
+    
     for i in 1:basis_size
-        if i < half_basis_size
-            hamdat[i, 1, indmap_2L[1, i, 1, i]] += ut_apap
-            hamdat[i, 1, indmap_2L[2, i, 1, i]] += ut_amap
-            hamdat[i, 1, indmap_2L[1, i, 2, i]] += ut_apam
-            hamdat[i, 1, indmap_2L[2, i, 2, i]] += ut_amam
-            for loc in (i + 1):(half_basis_size - 1)
-                hamdat[loc, indmap_2L[1, i, 1, i], indmap_2L[1, i, 1, i]] = Elt(1)
-                hamdat[loc, indmap_2L[2, i, 1, i], indmap_2L[2, i, 1, i]] = Elt(1)
-                hamdat[loc, indmap_2L[1, i, 2, i], indmap_2L[1, i, 2, i]] = Elt(1)
-                hamdat[loc, indmap_2L[2, i, 2, i], indmap_2L[2, i, 2, i]] = Elt(1)
+        if i<half_basis_size
+            hamdat[i,1,indmap_2L[1,i,1,i]] += ut_apap;
+            hamdat[i,1,indmap_2L[2,i,1,i]] += ut_amap;
+            hamdat[i,1,indmap_2L[1,i,2,i]] += ut_apam;
+            hamdat[i,1,indmap_2L[2,i,2,i]] += ut_amam;
+            for loc in i+1:half_basis_size-1
+                hamdat[loc,indmap_2L[1,i,1,i],indmap_2L[1,i,1,i]] = Elt(1);
+                hamdat[loc,indmap_2L[2,i,1,i],indmap_2L[2,i,1,i]] = Elt(1);
+                hamdat[loc,indmap_2L[1,i,2,i],indmap_2L[1,i,2,i]] = Elt(1);
+                hamdat[loc,indmap_2L[2,i,2,i],indmap_2L[2,i,2,i]] = Elt(1);
             end
         elseif i > half_basis_size
-            hamdat[i, indmap_2R[1, i, 1, i], end] += bpbp_ut
-            hamdat[i, indmap_2R[2, i, 1, i], end] += bmbp_ut
-            hamdat[i, indmap_2R[1, i, 2, i], end] += bpbm_ut
-            hamdat[i, indmap_2R[2, i, 2, i], end] += bmbm_ut
-            for loc in (half_basis_size + 1):(i - 1)
-                hamdat[loc, indmap_2R[1, i, 1, i], indmap_2R[1, i, 1, i]] = Elt(1)
-                hamdat[loc, indmap_2R[2, i, 1, i], indmap_2R[2, i, 1, i]] = Elt(1)
-                hamdat[loc, indmap_2R[1, i, 2, i], indmap_2R[1, i, 2, i]] = Elt(1)
-                hamdat[loc, indmap_2R[2, i, 2, i], indmap_2R[2, i, 2, i]] = Elt(1)
+            hamdat[i,indmap_2R[1,i,1,i],end] += bpbp_ut;
+            hamdat[i,indmap_2R[2,i,1,i],end] += bmbp_ut;
+            hamdat[i,indmap_2R[1,i,2,i],end] += bpbm_ut;
+            hamdat[i,indmap_2R[2,i,2,i],end] += bmbm_ut;
+            for loc in half_basis_size+1:i-1
+                hamdat[loc,indmap_2R[1,i,1,i],indmap_2R[1,i,1,i]] = Elt(1);
+                hamdat[loc,indmap_2R[2,i,1,i],indmap_2R[2,i,1,i]] = Elt(1);
+                hamdat[loc,indmap_2R[1,i,2,i],indmap_2R[1,i,2,i]] = Elt(1);
+                hamdat[loc,indmap_2R[2,i,2,i],indmap_2R[2,i,2,i]] = Elt(1);
             end
         end
     end
 
     # indmap_2 disconnected part
-    iso_pp = isomorphism(_lastspace(ap)', _lastspace(ap)')
-    iso_mm = isomorphism(_lastspace(am)', _lastspace(am)')
+    iso_pp = isomorphism(_lastspace(ap)',_lastspace(ap)');
+    iso_mm = isomorphism(_lastspace(am)',_lastspace(am)');
 
-    @plansor p_ap[-1 -2; -3 -4] := iso_pp[-1; 1] * τ[1 2; -3 3] * ap[2 -2; 4] * conj(pp_f[-4; 3 4])
-    @plansor m_ap[-1 -2; -3 -4] := iso_mm[-1; 1] * τ[1 2; -3 3] * ap[2 -2; 4] * conj(mp_f[-4; 3 4])
-    @plansor p_am[-1 -2; -3 -4] := iso_pp[-1; 1] * τ[1 2; -3 3] * am[2 -2; 4] * conj(pm_f[-4; 3 4])
-    @plansor m_am[-1 -2; -3 -4] := iso_mm[-1; 1] * τ[1 2; -3 3] * am[2 -2; 4] * conj(mm_f[-4; 3 4])
+    @plansor p_ap[-1 -2;-3 -4] := iso_pp[-1;1]*τ[1 2;-3 3]*ap[2 -2;4]*conj(pp_f[-4;3 4]);
+    @plansor m_ap[-1 -2;-3 -4] := iso_mm[-1;1]*τ[1 2;-3 3]*ap[2 -2;4]*conj(mp_f[-4;3 4]);
+    @plansor p_am[-1 -2;-3 -4] := iso_pp[-1;1]*τ[1 2;-3 3]*am[2 -2;4]*conj(pm_f[-4;3 4]);
+    @plansor m_am[-1 -2;-3 -4] := iso_mm[-1;1]*τ[1 2;-3 3]*am[2 -2;4]*conj(mm_f[-4;3 4]);
 
-    @plansor bp_p[-1 -2; -3 -4] := bp[2; -3 3] * iso_mm[1; -4] * τ[4 -2; 3 1] * mm_f[-1; 2 4]
-    @plansor bm_p[-1 -2; -3 -4] := bm[2; -3 3] * iso_mm[1; -4] * τ[4 -2; 3 1] * pm_f[-1; 2 4]
-    @plansor bm_m[-1 -2; -3 -4] := bm[2; -3 3] * iso_pp[1; -4] * τ[4 -2; 3 1] * pp_f[-1; 2 4]
-    @plansor bp_m[-1 -2; -3 -4] := bp[2; -3 3] * iso_pp[1; -4] * τ[4 -2; 3 1] * mp_f[-1; 2 4]
+    @plansor bp_p[-1 -2;-3 -4] := bp[2;-3 3]*iso_mm[1;-4]*τ[4 -2;3 1]*mm_f[-1;2 4]
+    @plansor bm_p[-1 -2;-3 -4] := bm[2;-3 3]*iso_mm[1;-4]*τ[4 -2;3 1]*pm_f[-1;2 4]
+    @plansor bm_m[-1 -2;-3 -4] := bm[2;-3 3]*iso_pp[1;-4]*τ[4 -2;3 1]*pp_f[-1;2 4]
+    @plansor bp_m[-1 -2;-3 -4] := bp[2;-3 3]*iso_pp[1;-4]*τ[4 -2;3 1]*mp_f[-1;2 4]
 
-    for i in 1:basis_size, j in (i + 1):basis_size
-        if j < half_basis_size
-            hamdat[j, indmap_1L[1, i], indmap_2L[1, i, 1, j]] += p_ap
-            hamdat[j, indmap_1L[1, i], indmap_2L[1, i, 2, j]] += p_am
-            hamdat[j, indmap_1L[2, i], indmap_2L[2, i, 1, j]] += m_ap
-            hamdat[j, indmap_1L[2, i], indmap_2L[2, i, 2, j]] += m_am
-            for k in (j + 1):(half_basis_size - 1)
-                hamdat[k, indmap_2L[1, i, 1, j], indmap_2L[1, i, 1, j]] = Elt(1)
-                hamdat[k, indmap_2L[1, i, 2, j], indmap_2L[1, i, 2, j]] = Elt(1)
-                hamdat[k, indmap_2L[2, i, 2, j], indmap_2L[2, i, 2, j]] = Elt(1)
-                hamdat[k, indmap_2L[2, i, 1, j], indmap_2L[2, i, 1, j]] = Elt(1)
+    for i in 1:basis_size, j in i+1:basis_size
+        if j<half_basis_size
+            hamdat[j,indmap_1L[1,i],indmap_2L[1,i,1,j]] += p_ap;
+            hamdat[j,indmap_1L[1,i],indmap_2L[1,i,2,j]] += p_am;
+            hamdat[j,indmap_1L[2,i],indmap_2L[2,i,1,j]] += m_ap;
+            hamdat[j,indmap_1L[2,i],indmap_2L[2,i,2,j]] += m_am;
+            for k in j+1:half_basis_size-1
+                hamdat[k,indmap_2L[1,i,1,j],indmap_2L[1,i,1,j]] = Elt(1);
+                hamdat[k,indmap_2L[1,i,2,j],indmap_2L[1,i,2,j]] = Elt(1);
+                hamdat[k,indmap_2L[2,i,2,j],indmap_2L[2,i,2,j]] = Elt(1);
+                hamdat[k,indmap_2L[2,i,1,j],indmap_2L[2,i,1,j]] = Elt(1);
             end
         end
 
         if i > half_basis_size
-            hamdat[i, indmap_2R[1, i, 1, j], indmap_1R[1, j]] += bp_p
-            hamdat[i, indmap_2R[1, i, 2, j], indmap_1R[2, j]] += bp_m
-            hamdat[i, indmap_2R[2, i, 1, j], indmap_1R[1, j]] += bm_p
-            hamdat[i, indmap_2R[2, i, 2, j], indmap_1R[2, j]] += bm_m
-            for k in (half_basis_size + 1):(i - 1)
-                hamdat[k, indmap_2R[1, i, 1, j], indmap_2R[1, i, 1, j]] = Elt(1)
-                hamdat[k, indmap_2R[1, i, 2, j], indmap_2R[1, i, 2, j]] = Elt(1)
-                hamdat[k, indmap_2R[2, i, 2, j], indmap_2R[2, i, 2, j]] = Elt(1)
-                hamdat[k, indmap_2R[2, i, 1, j], indmap_2R[2, i, 1, j]] = Elt(1)
+            hamdat[i,indmap_2R[1,i,1,j],indmap_1R[1,j]] += bp_p;
+            hamdat[i,indmap_2R[1,i,2,j],indmap_1R[2,j]] += bp_m;
+            hamdat[i,indmap_2R[2,i,1,j],indmap_1R[1,j]] += bm_p;
+            hamdat[i,indmap_2R[2,i,2,j],indmap_1R[2,j]] += bm_m;
+            for k in half_basis_size+1:i-1
+                hamdat[k,indmap_2R[1,i,1,j],indmap_2R[1,i,1,j]] = Elt(1);
+                hamdat[k,indmap_2R[1,i,2,j],indmap_2R[1,i,2,j]] = Elt(1);
+                hamdat[k,indmap_2R[2,i,2,j],indmap_2R[2,i,2,j]] = Elt(1);
+                hamdat[k,indmap_2R[2,i,1,j],indmap_2R[2,i,1,j]] = Elt(1);
             end
         end
-    end
 
+    end
+    
+    
     # fill in all T terms
     # 1 | 1
-    for i in 1:basis_size, j in (i + 1):basis_size
+    for i in 1:basis_size, j in i+1:basis_size
         # m | p .
-        hamdat[j, map_1[2, i], end] += K[j, i] * bp_ut
-
+        hamdat[j,indmap_1L[2,i],end] += K[j,i]*bp_ut;
+        
         # p | . m
-        hamdat[j, map_1[1, i], end] += K[i, j] * bm_ut
+        hamdat[j,indmap_1L[1,i],end] += K[i,j]*bm_ut;
     end
-
+    
+    
     # fill in all V terms
 
+    
     # 1|3
-    @plansor ppLm[-1 -2; -3 -4] := bp[-1; 1 -2] * h_pm[1; -3] * conj(ut[-4])
-    @plansor Lpmm[-1 -2; -3 -4] := bm[-1; -3 1] * h_pm[-2; 1] * conj(ut[-4])
-    for i in 1:basis_size, j in (i + 1):basis_size
+    @plansor ppLm[-1 -2;-3 -4] := bp[-1;1 -2]*h_pm[1;-3]*conj(ut[-4])
+    @plansor Lpmm[-1 -2;-3 -4] := bm[-1;-3 1]*h_pm[-2;1]*conj(ut[-4])
+    for i in 1:basis_size,j in i+1:basis_size
         # m | p p . m
         # m | p p m .
-        hamdat[j, indmap_1L[2, i], end] += (V[j, j, i, j] + V[j, j, j, i]) * ppLm
+        hamdat[j,indmap_1L[2,i],end] += (V[j,j,i,j]+V[j,j,j,i])*ppLm;
 
         # p | . p m m
         # p | p . m m
-        hamdat[j, indmap_1L[1, i], end] += (V[j, i, j, j] + V[i, j, j, j]) * Lpmm
+        hamdat[j,indmap_1L[1,i],end] += (V[j,i,j,j]+V[i,j,j,j])*Lpmm;
     end
-
+    
     # 3|1
-    for i in 1:basis_size, j in (i + 1):basis_size
+    @plansor ppRm[-1 -2;-3 -4] := ut[-1]*ap[1 -2;-4]*h_pm[1;-3]
+    @plansor Rpmm[-1 -2;-3 -4] := ut[-1]*h_pm[-2;1]*am[-3 1;-4]
+    for i in 1:basis_size,j in i+1:basis_size
         # p p . m | m
-        @plansor pp_m[-1 -2; -3 -4] := ut[-1] * ap[1 -2; -4] * h_pm[1; -3]
-        hamdat[i, 1, map_4[2, j]] += V[i, i, j, i] * pp_m
-
         # p p m . | m
-        @plansor ppm_[-1 -2; -3 -4] := ut[-1] * ap[1 -2; -4] * h_pm[1; -3]
-        hamdat[i, 1, map_4[2, j]] += V[i, i, i, j] * ppm_
+        hamdat[i,1,indmap_1R[2,j]] += (V[i,i,j,i]+V[i,i,i,j])*ppRm
 
         # . p m m | p
-        @plansor _pmm[-1 -2; -3 -4] := ut[-1] * h_pm[-2; 1] * am[-3 1; -4]
-        hamdat[i, 1, map_4[1, j]] += V[j, i, i, i] * _pmm
-
         # p . m m | p
-        @plansor p_mm[-1 -2; -3 -4] := ut[-1] * h_pm[-2; 1] * am[-3 1; -4]
-        hamdat[i, 1, map_4[1, j]] += V[i, j, i, i] * p_mm
+        hamdat[i,1,indmap_1R[1,j]] += (V[j,i,i,i]+V[i,j,i,i])*Rpmm
     end
 
-    # 1|3
-    for i in 1:basis_size, j in (i + 1):basis_size
-        # m | p p . m
-        @plansor pp_m[-1 -2; -3 -4] := bp[-1; 1 -2] * h_pm[1; -3] * conj(ut[-4])
-        hamdat[j, map_1[2, i], end] += V[j, j, i, j] * pp_m
-
-        # m | p p m .
-        @plansor ppm_[-1 -2; -3 -4] := bp[-1; 1 -2] * h_pm[1; -3] * conj(ut[-4])
-        hamdat[j, map_1[2, i], end] += V[j, j, j, i] * ppm_
-
-        # p | . p m m
-        @plansor _pmm[-1 -2; -3 -4] := bm[-1; -3 1] * h_pm[-2; 1] * conj(ut[-4])
-        hamdat[j, map_1[1, i], end] += V[i, j, j, j] * _pmm
-
-        # p | p . m m
-        @plansor p_mm[-1 -2; -3 -4] := bm[-1; -3 1] * h_pm[-2; 1] * conj(ut[-4])
-        hamdat[j, map_1[1, i], end] += V[j, i, j, j] * p_mm
-    end
-
-    # 2|2
-    for i in 1:basis_size, j in (i + 1):basis_size
-        # p p | . . m m
-        @plansor __mm[-1 -2; -3 -4] := pp_f[-1; 1 2] * bm[1; -3 3] * bm[2; 3 -2] * conj(ut[-4])
-        hamdat[j, map_2[1, i, 1, i], end] += V[i, i, j, j] * __mm
-
-        # m m | p p . .
-        @plansor __pp[-1 -2; -3 -4] := mm_f[-1; 1 2] * bp[1; -3 3] * bp[2; 3 -2] * conj(ut[-4])
-        hamdat[j, map_2[2, i, 2, i], end] += V[j, j, i, i] * __pp
-
-        # p m | . p . m
-        @plansor _p_m[-1 -2; -3 -4] := mp_f[-1; 1 2] * bp[1; -3 3] * bm[2; 3 -2] * conj(ut[-4])
-        hamdat[j, map_2[2, i, 1, i], end] += V[i, j, i, j] * _p_m
-        hamdat[i, 1, end] -= V[i, j, i, j] * h_pm
-
-        # p m | p . m .
-        p_m_ = _p_m
-        hamdat[j, map_2[2, i, 1, i], end] += V[j, i, j, i] * p_m_
-        hamdat[i, 1, end] -= V[j, i, j, i] * h_pm
-
-        # p m | . p m .
-        @plansor _pm_[-1 -2; -3 -4] := ut[-1] * h_pm[-2; -3] * conj(ut[-4])
-        hamdat[j, map_3[2, i, 1, i], end] += V[i, j, j, i] * _pm_
-
-        # p m | p . . m
-        p__m = _pm_
-        hamdat[j, map_3[2, i, 1, i], end] += V[j, i, i, j] * p__m
-    end
 
     # 1|2|1
-    for i in 1:basis_size, j in (i + 1):basis_size, k in (j + 1):basis_size
+    @plansor LRmm[-1 -2;-3 -4] := am[1 -2;-4]*bm[-1;-3 1]
+    @plansor RLmm[-1 -2;-3 -4] := bm[-1;1 -2]*am[-3 1;-4]
+
+    @plansor ppLR[-1 -2;-3 -4] := ap[1 -2;-4]*bp[-1;-3 1]
+    @plansor ppRL[-1 -2;-3 -4] := bp[-1;1 -2]*ap[-3 1;-4]
+
+    @plansor LpRm[-1 -2;-3 -4] := ap[1 -2;-4]*bm[-1;-3 1]
+    @plansor pLmR[-1 -2;-3 -4] := ap[1 -2;-4]*bm[-1;-3 1]
+    
+    @plansor RpLm[-1 -2;-3 -4] := bp[-1;1 -2]*am[-3 1;-4]
+    @plansor pRmL[-1 -2;-3 -4] := bp[-1;1 -2]*am[-3 1;-4]
+
+    @plansor LpmR[-1 -2;-3 -4] := h_pm[4;-3]*iso_pp[-1;3]*τ[3 -2;4 -4]
+    @plansor pLRm[-1 -2;-3 -4] := iso_pp[-1;1]*τ[1 -2;2 -4]*h_pm[2;-3]
+
+    @plansor RpmL[-1 -2;-3 -4] := h_pm[4;-3]*iso_mm[-1;3]*τ[3 -2;4 -4]
+    @plansor pRLm[-1 -2;-3 -4] := iso_mm[-1;1]*τ[1 -2;2 -4]*h_pm[2;-3]
+    
+    for i in 1:basis_size,j in i+1:basis_size,k in j+1:basis_size
         # L R m m
-        @plansor LRmm[-1 -2; -3 -4] := am[1 -2; -4] * bm[-1; -3 1]
-        hamdat[j, map_1[1, i], map_4[1, k]] += V[i, k, j, j] * LRmm
-
-        # p p L R
-        @plansor LRmm[-1 -2; -3 -4] := ap[1 -2; -4] * bp[-1; -3 1]
-        hamdat[j, map_1[2, i], map_4[2, k]] += V[j, j, i, k] * LRmm
-
-        # L p R m
-        @plansor LpRm[-1 -2; -3 -4] := ap[1 -2; -4] * bm[-1; -3 1]
-        hamdat[j, map_1[1, i], map_4[2, k]] += V[i, j, k, j] * LpRm
-
-        # R p L m
-        @plansor RpLm[-1 -2; -3 -4] := bp[-1; 1 -2] * am[-3 1; -4]
-        hamdat[j, map_1[2, i], map_4[1, k]] += V[k, j, i, j] * RpLm
-
-        # p L m R
-        @plansor pLmR[-1 -2; -3 -4] := ap[1 -2; -4] * bm[-1; -3 1]
-        hamdat[j, map_1[1, i], map_4[2, k]] += V[j, i, j, k] * pLmR
-
-        # L p m R
-        @plansor LpmR[-1 -2; -3 -4] := h_pm[4; -3] * iso_pp[-1; 3] * τ[3 -2; 4 -4]
-        hamdat[j, map_1[1, i], map_4[2, k]] += V[i, j, j, k] * LpmR
-
-        # p L R m
-        @plansor pLRm[-1 -2; -3 -4] := iso_pp[-1; 1] * τ[1 -2; 2 -4] * h_pm[2; -3]
-        hamdat[j, map_1[1, i], map_4[2, k]] += V[j, i, k, j] * pLRm
+        hamdat[j,indmap_1L[1,i],indmap_1R[1,k]] += V[i,k,j,j]*LRmm
 
         # R L m m
-        @plansor RLmm[-1 -2; -3 -4] := bm[-1; 1 -2] * am[-3 1; -4]
-        hamdat[j, map_1[1, i], map_4[1, k]] += V[k, i, j, j] * RLmm
-
-        # p R m L
-        @plansor pRmL[-1 -2; -3 -4] := bp[-1; 1 -2] * am[-3 1; -4]
-        hamdat[j, map_1[2, i], map_4[1, k]] += V[j, k, j, i] * pRmL
+        hamdat[j,indmap_1L[1,i],indmap_1R[1,k]] += V[k,i,j,j]*RLmm;
+        
+        # p p L R
+        hamdat[j,indmap_1L[2,i],indmap_1R[2,k]] += V[j,j,i,k]*ppLR
 
         # p p R L
-        @plansor ppRL[-1 -2; -3 -4] := bp[-1; 1 -2] * ap[-3 1; -4]
-        hamdat[j, map_1[2, i], map_4[2, k]] += V[j, j, k, i] * ppRL
+        hamdat[j,indmap_1L[2,i],indmap_1R[2,k]] += V[j,j,k,i]*ppRL
+
+        # L p R m
+        # p L m R
+        hamdat[j,indmap_1L[1,i],indmap_1R[2,k]] += (V[j,i,j,k]+V[i,j,k,j])*LpRm
+
+        # R p L m
+        # p R m L
+        hamdat[j,indmap_1L[2,i],indmap_1R[1,k]] += (V[j,k,j,i]+V[k,j,i,j])*RpLm
+
+        # L p m R
+        hamdat[j,indmap_1L[1,i],indmap_1R[2,k]] += V[i,j,j,k]*LpmR
+
+        # p L R m
+        hamdat[j,indmap_1L[1,i],indmap_1R[2,k]] += V[j,i,k,j]*pLRm
 
         # R p m L
-        @plansor RpmL[-1 -2; -3 -4] := h_pm[4; -3] * iso_mm[-1; 3] * τ[3 -2; 4 -4]
-        hamdat[j, map_1[2, i], map_4[1, k]] += V[k, j, j, i] * RpmL
+        hamdat[j,indmap_1L[2,i],indmap_1R[1,k]] += V[k,j,j,i]*RpmL
 
         # p R L m
-        @plansor pRLm[-1 -2; -3 -4] := iso_mm[-1; 1] * τ[1 -2; 2 -4] * h_pm[2; -3]
-        hamdat[j, map_1[2, i], map_4[1, k]] += V[j, k, i, j] * pRLm
+        hamdat[j,indmap_1L[2,i],indmap_1R[1,k]] += V[j,k,i,j]*pRLm
     end
+    
+    
+    # 2|2
+    @plansor __mm[-1 -2;-3 -4] := pp_f[-1;1 2]*bm[1;-3 3]*bm[2;3 -2]*conj(ut[-4])
+    @plansor __pp[-1 -2;-3 -4] := mm_f[-1;1 2]*bp[1;-3 3]*bp[2;3 -2]*conj(ut[-4])
+    @plansor _p_m[-1 -2;-3 -4] := mp_f[-1;1 2] * bp[1;-3 3]*bm[2;3 -2]*conj(ut[-4])
+    @plansor _pm_[-1 -2;-3 -4] := mp_f[-1;1 2]*Lmap_apam_to_pm[1 2]*h_pm[-2;-3]*conj(ut[-4])
+    p_m_ = _p_m;
+    p__m = _pm_;
+    
+    for i in 1:half_basis_size, j in i+1:half_basis_size
+        # p p | . . m m
+        hamdat[j,indmap_2L[1,i,1,i],end] += V[i,i,j,j]*__mm;
 
+        # m m | p p . .
+        hamdat[j,indmap_2L[2,i,2,i],end] += V[j,j,i,i]*__pp;
+
+        # p m | . p . m
+        hamdat[j,indmap_2L[2,i,1,i],end] += V[i,j,i,j]*_p_m;
+        hamdat[i,1,end] -= V[i,j,i,j]*add_util_leg(h_pm);
+
+        # p m | p . m .
+        hamdat[j,indmap_2L[2,i,1,i],end] += V[j,i,j,i]*p_m_;
+        hamdat[i,1,end] -= V[j,i,j,i]*add_util_leg(h_pm);
+        
+        # p m | . p m .
+        hamdat[j,indmap_2L[2,i,1,i],end] += V[i,j,j,i]*_pm_;
+
+        # p m | p . . m
+        hamdat[j,indmap_2L[2,i,1,i],end] += V[j,i,i,j]*_pm_;
+    end
+    
+    @plansor __mm[-1 -2;-3 -4] := ut[-1]*am[-3 1;2]*am[1 -2;3]*conj(mm_f[-4;2 3])
+    @plansor __pp[-1 -2;-3 -4] := ut[-1]*ap[-3 1;2]*ap[1 -2;3]*conj(pp_f[-4;2 3])
+    @plansor _p_m[-1 -2;-3 -4] := ut[-1]*ap[-3 1;2]*am[1 -2;3]*conj(pm_f[-4;2 3])
+    p_m_ = _p_m;
+    @plansor _pm_[-1 -2;-3 -4] := ut[-1]*h_pm[-2;-3]*(transpose(Rmap_bpbm_to_pm*pm_f',(1,)))[-4]
+    p__m = _pm_
+    
+    for i in half_basis_size:basis_size, j in i+1:basis_size
+        #  . . m m | p p
+        hamdat[i,1,indmap_2R[1,j,1,j]] += V[j,j,i,i]*__mm;
+
+        # p p . . | m m 
+        hamdat[i,1,indmap_2R[2,j,2,j]] += V[i,i,j,j]*__pp;
+
+        # . p . m | p m
+        hamdat[i,1,indmap_2R[2,j,1,j]] += V[j,i,j,i]*_p_m;
+        hamdat[j,1,end] -= V[j,i,j,i]*add_util_leg(h_pm);
+
+        #  p . m . | p m
+        hamdat[i,1,indmap_2R[2,j,1,j]] += V[i,j,i,j]*_p_m;
+        hamdat[j,1,end] -= V[i,j,i,j]*add_util_leg(h_pm);
+        
+        #  . p m . | p m
+        hamdat[i,1,indmap_2R[2,j,1,j]] += V[i,j,j,i]*_pm_;
+
+        #  p . . m | p m
+        hamdat[i,1,indmap_2R[2,j,1,j]] += V[j,i,i,j]*_pm_;
+    end
+    
+    
+    for i in 1:half_basis_size-1, j in half_basis_size+1:basis_size
+        # m m | p p
+        mmpp = permute(isometry(storagetype(ap),_firstspace(mm_f)*psp,_firstspace(mm_f)*psp),(1,2),(4,3));
+        hamdat[half_basis_size,indmap_2L[2,i,2,i],indmap_2R[1,j,1,j]] += mmpp*(V[j,j,i,i])
+
+        # p p | m p
+        ppmm = permute(isometry(storagetype(ap),_firstspace(pp_f)*psp,_firstspace(pp_f)*psp),(1,2),(4,3));
+        hamdat[half_basis_size,indmap_2L[1,i,1,i],indmap_2R[2,j,2,j]] += ppmm*(V[i,i,j,j])
+
+        # . p . m | p m
+        # p . m . | p m 
+        @plansor RLRL[-1 -2;-3 -4] := pm_f[-1;1 2]*ai[3;-3]*τ[3 1;4 5]*τ[5 2;6 -2]*conj(pm_f[-4;4 6])
+        hamdat[half_basis_size,indmap_2L[1,i,2,i],indmap_2R[2,j,1,j]] += (V[i,j,i,j]+V[j,i,j,i])*RLRL;
+        hamdat[j,1,end] -= add_util_leg(h_pm)*(V[i,j,i,j]+V[j,i,j,i])
+        
+        # . p m .
+        # p . . m
+        @plansor RLLR[-1 -2;-3 -4] := mp_f[-1;1 2]*Lmap_apam_to_pm[1 2]*ai[-2;-3]*(transpose(Rmap_bpbm_to_pm*pm_f',(1,)))[-4]
+        hamdat[half_basis_size,indmap_2L[2,i,1,i],indmap_2R[2,j,1,j]] += (V[i,j,j,i]+V[j,i,i,j])*RLLR;
+    end
+    
+    
     # 2|1|1
-    # (i,j) in map_2, 1 in map_4, 1 onsite
-    for i in 1:basis_size, j in (i + 1):basis_size, k in (j + 1):basis_size
-        # L L m R
-        @plansor LLmR[-1 -2; -3 -4] := pp_f[-1; 1 2] * bm[1; -3 3] * τ[3 2; -4 -2]
-        hamdat[j, map_2[1, i, 1, i], map_4[2, k]] += V[i, i, j, k] * LLmR
+    @plansor __mm[-1 -2;-3 -4]:= am[-3 1;2]*am[1 -2;3]*conj(mm_f[-4;2 3])*ut[-1]
+    @plansor pp__[-1 -2;-3 -4] := ap[-3 1;2]*ap[1 -2;3]*conj(pp_f[-4;2 3])*ut[-1]
+    @plansor pjkm[-1 -2;-3 -4] := ut[-1]*h_pm[-2;-3]*Rmap_bp_to_ap[1;2]*conj(mp_f[-4;1 2])
+    @plansor pkjm[-1 -2;-3 -4] := ut[-1]*h_pm[-2;-3]*Rmap_bm_to_am[1;2]*conj(pm_f[-4;1 2])
+    @plansor jpkm[-1 -2;-3 -4] := am[-3 1;2]*ap[1 -2;3]*conj(mp_f[-4;2 3])*ut[-1]
+    @plansor kpjm[-1 -2;-3 -4] := ap[-3 1;2]*am[1 -2;3]*conj(pm_f[-4;2 3])*ut[-1]
+    @plansor kpjm[-1 -2;-3 -4] := am[-3 1;4]*ap[1 -2;5]*τ[4 5;2 3]*conj(pm_f[-4;2 3])*ut[-1]
 
+    @plansor LLmR[-1 -2;-3 -4] := pp_f[-1;1 2]*bm[1;-3 3]*τ[3 2;-4 -2]
+    @plansor RpLL[-1 -2;-3 -4] := mm_f[-1;1 2]*bp[2;3 -2]*τ[1 3;-3 -4]
+    @plansor pLRL[-1 -2;-3 -4] := mp_f[-1;1 2]*bp[1;-3 3]*τ[3 2;-4 -2]
+    @plansor LRLm[-1 -2;-3 -4] := mp_f[-1;1 2]*bm[2;3 -2]*τ[1 3;-3 -4]
+    @plansor LpRL[-1 -2;-3 -4] := mp_f[-1;1 2]*Lmap_apam_to_pm[1 2]*ap[-3 -2;-4]
+    @plansor LRmL[-1 -2;-3 -4] := mp_f[-1;1 2]*Lmap_apam_to_pm[1 2]*am[-3 -2;-4]
+
+    for i in half_basis_size:basis_size,j in i+1:basis_size,k in j+1:basis_size
+        # j k m m
+        # k j m m
+        hamdat[i,1,indmap_2R[1,j,1,k]] += (V[j,k,i,i]+V[k,j,i,i])*__mm;
+        
+        # p p j k
+        # p p k j
+        hamdat[i,1,indmap_2R[2,j,2,k]] += (V[i,i,j,k]+V[i,i,k,j])*pp__;
+        
+        # p j k m
+        # j p m k
+        hamdat[i,1,indmap_2R[1,j,2,k]] += (V[j,i,i,k]+V[i,j,k,i])*pjkm
+        
+        # p k j m
+        # k p m j
+        hamdat[i,1,indmap_2R[2,j,1,k]] += (V[k,i,i,j]+V[i,k,j,i])*pkjm
+
+        # j p k m
+        # p j m k
+        hamdat[i,1,indmap_2R[1,j,2,k]] += (V[i,j,i,k]+V[j,i,k,i])*jpkm;
+
+        # k p j m
+        # p k m j
+        hamdat[i,1,indmap_2R[2,j,1,k]] += (V[i,k,i,j]+V[k,i,j,i])*kpjm        
+    end
+    
+    for i in 1:half_basis_size,j in i+1:half_basis_size,k in j+1:basis_size
+        # L L m R    
         # L L R m
-        @plansor LLRm[-1 -2; -3 -4] := pp_f[-1; 1 2] * bm[2; 3 -2] * τ[1 3; -3 -4]
-        hamdat[j, map_2[1, i, 1, i], map_4[2, k]] += V[i, i, k, j] * LLRm
+        hamdat[j,indmap_2L[1,i,1,i],indmap_1R[2,k]] += (V[i,i,k,j]+V[i,i,j,k])*LLmR
+
+        # R p L L
+        # p R L L
+        hamdat[j,indmap_2L[2,i,2,i],indmap_1R[1,k]] += (V[j,k,i,i]+V[k,j,i,i])*RpLL
 
         # p L R L
         # L p L R
-        @plansor LpLR[-1 -2; -3 -4] := mp_f[-1; 1 2] * bp[1; -3 3] * τ[3 2; -4 -2]
-        hamdat[j, map_2[2, i, 1, i], map_4[2, k]] += V[i, j, i, k] * LpLR
-
+        hamdat[j,indmap_2L[2,i,1,i],indmap_1R[2,k]] += (V[i,j,i,k]+V[j,i,k,i])*pLRL
+        
         # L R L m
-        @plansor LRLm[-1 -2; -3 -4] := mp_f[-1; 1 2] * bm[2; 3 -2] * τ[1 3; -3 -4]
-        hamdat[j, map_2[2, i, 1, i], map_4[1, k]] += V[i, k, i, j] * LRLm
-
-        # p L R L
-        @plansor pLRL[-1 -2; -3 -4] := mp_f[-1; 1 2] * bp[1; -3 3] * τ[3 2; -4 -2]
-        hamdat[j, map_2[2, i, 1, i], map_4[2, k]] += V[j, i, k, i] * pLRL
-
         # R L m L
-        @plansor RLmL[-1 -2; -3 -4] := mp_f[-1; 1 2] * bm[2; 3 -2] * τ[1 3; -3 -4]
-        hamdat[j, map_2[2, i, 1, i], map_4[1, k]] += V[k, i, j, i] * RLmL
-
-        # R p L L
-        @plansor RpLL[-1 -2; -3 -4] := mm_f[-1; 1 2] * bp[2; 3 -2] * τ[1 3; -3 -4]
-        hamdat[j, map_2[2, i, 2, i], map_4[1, k]] += V[k, j, i, i] * RpLL
-
-        # p R L L
-        @plansor pRLL[-1 -2; -3 -4] := mm_f[-1; 1 2] * bp[1; -3 3] * τ[3 2; -4 -2]
-        hamdat[j, map_2[2, i, 2, i], map_4[1, k]] += V[j, k, i, i] * pRLL
+        hamdat[j,indmap_2L[2,i,1,i],indmap_1R[1,k]] += (V[k,i,j,i]+V[i,k,i,j])*LRLm
 
         # L p R L
-        @plansor LpRL[-1 -2; -3 -4] := ut[-1] * ap[-3 -2; -4]
-        hamdat[j, map_3[2, i, 1, i], map_4[2, k]] += V[i, j, k, i] * LpRL
+        # p L L R
+        hamdat[j,indmap_2L[2,i,1,i],indmap_1R[2,k]] += (V[j,i,i,k]+V[i,j,k,i])*LpRL
 
         # L R m L
-        @plansor LRpL[-1 -2; -3 -4] := ut[-1] * am[-3 -2; -4]
-        hamdat[j, map_3[2, i, 1, i], map_4[1, k]] += V[i, k, j, i] * LRpL
-
-        # p L L R
-        @plansor pLLR[-1 -2; -3 -4] := ut[-1] * ap[-3 -2; -4]
-        hamdat[j, map_3[2, i, 1, i], map_4[2, k]] += V[j, i, i, k] * pLLR
-
         # R L L m
-        @plansor RLLm[-1 -2; -3 -4] := ut[-1] * am[-3 -2; -4]
-        hamdat[j, map_3[2, i, 1, i], map_4[1, k]] += V[k, i, i, j] * RLLm
+        hamdat[j,indmap_2L[2,i,1,i],indmap_1R[1,k]] += (V[k,i,i,j]+V[i,k,j,i])*LRmL 
     end
+    
+    for i in 1:half_basis_size-1,j in half_basis_size+1:basis_size,k in j+1:basis_size
+        # j k i i
+        # k j i i
+        @plansor jkii[-1 -2;-3 -4] := mm_f[-1;1 2]*ai[3;-3]*τ[3 1;4 5]*τ[5 2;6 -2]*conj(mm_f[-4;4 6])
+        hamdat[half_basis_size,indmap_2L[2,i,2,i],indmap_2R[1,j,1,k]] += (V[j,k,i,i]+V[k,j,i,i])*jkii;
+        
+        # i i j k
+        # i i k j
+        @plansor iijk[-1 -2;-3 -4] := pp_f[-1;1 2]*ai[3;-3]*τ[3 1;4 5]*τ[5 2;6 -2]*conj(pp_f[-4;4 6])
+        hamdat[half_basis_size,indmap_2L[1,i,1,i],indmap_2R[2,j,2,k]] += (V[i,i,j,k]+V[i,i,k,j])*iijk;
+        
+        # i j k i
+        # j i i k
+        @plansor ijki[-1 -2;-3 -4] := mp_f[-1;1 2]*Lmap_apam_to_pm[1 2]*ai[-2;-3]*Rmap_bp_to_ap[3;4]*conj(mp_f[-4;3 4])
+        hamdat[half_basis_size,indmap_2L[2,i,1,i],indmap_2R[1,j,2,k]] += (V[j,i,i,k]+V[i,j,k,i])*ijki
+        
+        # i k j i
+        # k i i j
+        @plansor ikji[-1 -2;-3 -4] := mp_f[-1;1 2]*Lmap_apam_to_pm[1 2]*ai[-2;-3]*Rmap_bm_to_am[3;4]*conj(pm_f[-4;3 4])
+        hamdat[half_basis_size,indmap_2L[2,i,1,i],indmap_2R[2,j,1,k]] += (V[k,i,i,j]+V[i,k,j,i])*ikji
 
+        # j i k i
+        # i j i k
+        @plansor jiki[-1 -2;-3 -4] := mp_f[-1;1 2]*ai[3;-3]*τ[3 1;4 5]*τ[5 2;6 -2]*conj(mp_f[-4;4 6])
+        hamdat[half_basis_size,indmap_2L[2,i,1,i],indmap_2R[1,j,2,k]] += (V[i,j,i,k]+V[j,i,k,i])*jiki;
+
+        # k i j i
+        # i k i j
+        @plansor kiji[-1 -2;-3 -4] := mp_f[-1;7 8]*τ[7 8;1 2] *ai[3;-3]*τ[3 1;4 5]*τ[5 2;6 -2]*conj(pm_f[-4;4 6])
+        hamdat[half_basis_size,indmap_2L[2,i,1,i],indmap_2R[2,j,1,k]] += (V[k,i,j,i]+V[i,k,i,j])*kiji;
+        
+    end
+    
+    
     # 1|1|2
-    # (i,j) in map_2, 2 onsite
-    for i in 1:basis_size, j in (i + 1):basis_size, k in (j + 1):basis_size
+    # (i,j) in indmap_2, 2 onsite
+    @plansor jimm[-1 -2;-3 -4] := bm[1;-3 2]*bm[3;2 -2]*τ[4 5;1 3]*pp_f[-1;4 5]*conj(ut[-4])
+    @plansor ijmm[-1 -2;-3 -4] := bm[1;-3 2]*bm[3;2 -2]*τ[4 5;1 3]*permute(pp_f,(1,),(3,2))[-1;4 5]*conj(ut[-4])
+    @plansor jpim[-1 -2;-3 -4] := bm[1;-3 2]*bp[3;2 -2]*τ[4 5;1 3]*mp_f[-1;4 5]*conj(ut[-4])
+    @plansor ipjm[-1 -2;-3 -4] := bm[1;-3 2]*bp[3;2 -2]*τ[4 5;1 3]*permute(pm_f,(1,),(3,2))[-1;4 5]*conj(ut[-4])
+    @plansor ppji[-1 -2;-3 -4] := mm_f[-1;1 2]*bp[1;-3 3]*bp[2;3 -2]*conj(ut[-4])
+    @plansor ppij[-1 -2;-3 -4] := permute(mm_f,(1,),(3,2))[-1;1 2]*bp[1;-3 3]*bp[2;3 -2]*conj(ut[-4])
+    @plansor jpmi[-1 -2;-3 -4] := ut[-1]*h_pm[-2;-3]*conj(ut[-4])
+    @plansor ipmj[-1 -2;-3 -4] := ut[-1]*h_pm[-2;-3]*conj(ut[-4])
+
+    pjmi = jpim;
+    pimj = ipjm;
+    
+    @plansor connect_am_ap[-1 -2;-3 -4] := mp_f[-1;1 2]*Lmap_ap_to_bp[2;1]*h_pm[-2;-3]*conj(ut[-4])
+    @plansor connect_ap_am[-1 -2;-3 -4] := pm_f[-1;1 2]*Lmap_am_to_bm[2;1]*h_pm[-2;-3]*conj(ut[-4])
+
+    for i in 1:basis_size,j in i+1:basis_size,k in j+1:basis_size
+        k <=half_basis_size || continue
+
         # j i m m
-        @plansor jimm[-1 -2; -3 -4] := bm[1; -3 2] * bm[3; 2 -2] * τ[4 5; 1 3] *
-            pp_f[-1; 4 5] * conj(ut[-4])
-        hamdat[k, map_2[1, i, 1, j], end] += V[j, i, k, k] * jimm
+        hamdat[k,indmap_2L[1,i,1,j],end] += V[j,i,k,k]*jimm
         # i j m m
-        @plansor ijmm[-1 -2; -3 -4] := bm[1; -3 2] *
-            bm[3; 2 -2] *
-            τ[4 5; 1 3] *
-            permute(pp_f, (1,), (3, 2))[-1; 4 5] *
-            conj(ut[-4])
-        hamdat[k, map_2[1, i, 1, j], end] += V[i, j, k, k] * ijmm
+        hamdat[k,indmap_2L[1,i,1,j],end] += V[i,j,k,k]*ijmm;
 
         # j p i m
-        @plansor jpim[-1 -2; -3 -4] := bm[1; -3 2] * bp[3; 2 -2] * τ[4 5; 1 3] *
-            mp_f[-1; 4 5] * conj(ut[-4])
-        hamdat[k, map_2[2, i, 1, j], end] += V[j, k, i, k] * jpim
+        hamdat[k,indmap_2L[2,i,1,j],end] += V[j,k,i,k]*jpim
+        hamdat[k,indmap_2L[2,i,1,j],end] += V[k,j,k,i]*pjmi
+
         # i p j m
-        @plansor ipjm[-1 -2; -3 -4] := bm[1; -3 2] * bp[3; 2 -2] *
-            τ[4 5; 1 3] * permute(pm_f, (1,), (3, 2))[-1; 4 5] * conj(ut[-4])
-        hamdat[k, map_2[1, i, 2, j], end] += V[i, k, j, k] * ipjm
+        hamdat[k,indmap_2L[1,i,2,j],end] += V[i,k,j,k]*ipjm
+        hamdat[k,indmap_2L[1,i,2,j],end] += V[k,i,k,j]*pimj
 
         # j p m i
-        @plansor jpmi[-1 -2; -3 -4] := ut[-1] * h_pm[-2; -3] * conj(ut[-4])
-        hamdat[k, map_3[2, i, 1, j], end] += V[j, k, k, i] * jpmi
+        hamdat[k,indmap_2L[2,i,1,j],end] += (V[j,k,k,i]+V[k,j,i,k])*connect_am_ap
+
         # i p m j
-        @plansor ipmj[-1 -2; -3 -4] := ut[-1] * h_pm[-2; -3] * conj(ut[-4])
-        hamdat[k, map_3[1, i, 2, j], end] += V[i, k, k, j] * ipmj
+        hamdat[k,indmap_2L[1,i,2,j],end] += (V[k,i,j,k]+V[i,k,k,j])*connect_ap_am
 
         # p p j i
-        @plansor ppji[-1 -2; -3 -4] := mm_f[-1; 1 2] * bp[1; -3 3] * bp[2; 3 -2] * conj(ut[-4])
-        hamdat[k, map_2[2, i, 2, j], end] += V[k, k, j, i] * ppji
+        hamdat[k,indmap_2L[2,i,2,j],end] += V[k,k,j,i]*ppji
         # p p i j
-        @plansor ppij[-1 -2; -3 -4] := permute(mm_f, (1,), (3, 2))[-1; 1 2] * bp[1; -3 3] *
-            bp[2; 3 -2] * conj(ut[-4])
-        hamdat[k, map_2[2, i, 2, j], end] += V[k, k, i, j] * ppij
-
-        # p . . m
-        pjim = jpmi
-        hamdat[k, map_3[2, i, 1, j], end] += V[k, j, i, k] * pjim
-        pijm = ipmj
-        hamdat[k, map_3[1, i, 2, j], end] += V[k, i, j, k] * pijm
-
-        # p . m .
-        pjmi = jpim
-        hamdat[k, map_2[2, i, 1, j], end] += V[k, j, k, i] * pjmi
-        pimj = ipjm
-        hamdat[k, map_2[1, i, 2, j], end] += V[k, i, k, j] * pimj
+        hamdat[k,indmap_2L[2,i,2,j],end] += V[k,k,i,j]*ppij
     end
 
+    @plansor jimm[-1 -2;-3 -4] := iso_pp[-1;1]*ap[-3 2;3]*τ[2 1;4 -2]*conj(pp_f[-4;3 4])
+    @plansor ppji[-1 -2;-3 -4] := iso_mm[-1;1]*am[-3 2;3]*τ[2 1;4 -2]*conj(mm_f[-4;3 4])
+    @plansor jpim[-1 -2;-3 -4] := iso_mm[-1;1]*ap[-3 2;3]*τ[2 1;4 -2]*conj(pm_f[-4;3 4])
+    @plansor ipjm[-1 -2;-3 -4] := iso_pp[-1;1]*τ[-3 1;2 3]*am[3 -2;4]*conj(pm_f[-4;2 4])
+    
+    @plansor jpmi[-1 -2;-3 -4] := bp[-1;-3 -2]*(transpose(Rmap_bpbm_to_pm*pm_f',(1,)))[-4]
+    @plansor ipmj[-1 -2;-3 -4] := bm[-1;-3 -2]*(transpose(Rmap_bpbm_to_pm*pm_f',(1,)))[-4]
+    for i in 1:basis_size,j in i+1:basis_size,k in j+1:basis_size
+        j >= half_basis_size || continue
+
+        # j i m m
+        # i j m m
+        hamdat[j,indmap_1L[1,i],indmap_2R[2,k,2,k]] += (V[j,i,k,k]+V[i,j,k,k])*jimm
+
+        # p p j i
+        # p p i j
+        hamdat[j,indmap_1L[2,i],indmap_2R[1,k,1,k]] += (V[k,k,j,i]+V[k,k,i,j])*ppji
+        
+        # j p i m
+        # p j m i
+        hamdat[j,indmap_1L[2,i],indmap_2R[2,k,1,k]] += (V[j,k,i,k]+V[k,j,k,i])*jpim
+
+        # i p j m
+        # p i m j
+        hamdat[j,indmap_1L[1,i],indmap_2R[2,k,1,k]] += (V[i,k,j,k]+V[k,i,k,j])*ipjm
+
+        # j p m i
+        # p j i m
+        hamdat[j,indmap_1L[2,i],indmap_2R[2,k,1,k]] += (V[k,j,i,k]+V[j,k,k,i])*jpmi
+
+        # i p m j
+        # p i j m
+        hamdat[j,indmap_1L[1,i],indmap_2R[2,k,1,k]] += (V[i,k,k,j]+V[k,i,j,k])*ipmj
+    end
+    
+    @plansor jikk[-1 -2;-3 -4] := pp_f[-1;1 2]*ai[3;-3]*τ[3 1;4 5]*τ[5 2;6 -2]*conj(pp_f[-4;4 6])
+    @plansor kkji[-1 -2;-3 -4] := mm_f[-1;1 2]*ai[3;-3]*τ[3 1;4 5]*τ[5 2;6 -2]*conj(mm_f[-4;4 6])
+    @plansor jkki[-1 -2;-3 -4] := mp_f[-1;1 2]*Lmap_ap_to_bp[2;1]*ai[-2;-3]*(transpose(Rmap_bpbm_to_pm*pm_f',(1,)))[-4]
+    @plansor ikkj[-1 -2;-3 -4] := pm_f[-1;1 2]*Lmap_am_to_bm[2;1]*ai[-2;-3]*(transpose(Rmap_bpbm_to_pm*pm_f',(1,)))[-4]
+    @plansor jkik[-1 -2;-3 -4] := mp_f[-1;1 2]*ai[3;-3]*τ[3 1;4 5]*τ[5 2;6 -2]*τ[4 6;7 8]*conj(pm_f[-4;7 8])
+    @plansor ikjk[-1 -2;-3 -4] := pm_f[-1;1 2]*ai[3;-3]*τ[3 1;4 5]*τ[5 2;6 -2]*conj(pm_f[-4;4 6])
+    for i in 1:half_basis_size-1,j in i+1:half_basis_size-1, k in half_basis_size+1:basis_size
+        # j i k k
+        # i j k k
+        hamdat[half_basis_size,indmap_2L[1,i,1,j],indmap_2R[2,k,2,k]] += (V[j,i,k,k]+V[i,j,k,k])*jikk
+
+        # k k j i
+        # k k i j
+        hamdat[half_basis_size,indmap_2L[2,i,2,j],indmap_2R[1,k,1,k]] += (V[k,k,j,i]+V[k,k,i,j])*kkji
+        
+        # j k k i
+        # k j i k
+        hamdat[half_basis_size,indmap_2L[2,i,1,j],indmap_2R[2,k,1,k]] += (V[k,j,i,k]+V[j,k,k,i])*jkki
+
+        # i k k j
+        # k i j k
+        hamdat[half_basis_size,indmap_2L[1,i,2,j],indmap_2R[2,k,1,k]] += (V[i,k,k,j]+V[k,i,j,k])*ikkj
+
+        # j k i k
+        # k j k i
+        hamdat[half_basis_size,indmap_2L[2,i,1,j],indmap_2R[2,k,1,k]] += (V[j,k,i,k]+V[k,j,k,i])*jkik
+        
+        # i k j k
+        # k i k j
+        hamdat[half_basis_size,indmap_2L[1,i,2,j],indmap_2R[2,k,1,k]] += (V[i,k,j,k]+V[k,i,k,j])*ikjk
+    end
+    
+    
     # 1|1|1|1
-    # (i,j) in map_2, 1 in map_4, 1 onsite
+    # (i,j) in indmap_2, 1 in indmap_4, 1 onsite
+    @plansor pjiR[-1 -2;-3 -4] := mp_f[-1;1 2]*Lmap_ap_to_bp[2;1]*ap[-3 -2;-4]
+    @plansor pijR[-1 -2;-3 -4] := pm_f[-1;1 2]*Lmap_am_to_bm[2;1]*ap[-3 -2;-4]
+    @plansor Rjim[-1 -2;-3 -4] := mp_f[-1;1 2]*Lmap_ap_to_bp[2;1]*am[-3 -2;-4]
+    @plansor Rijm[-1 -2;-3 -4] := pm_f[-1;1 2]*Lmap_am_to_bm[2;1]*am[-3 -2;-4]
+    @plansor jimR[-1 -2;-3 -4] := pp_f[-1;1 2]*τ[3 2;-4 -2]*bm[1;-3 3]
+    @plansor ijRm[-1 -2;-3 -4] := permute(pp_f,(1,),(3,2))[-1;1 2]*τ[1 3;-3 -4]*bm[2;3 -2]
+    @plansor ijmR[-1 -2;-3 -4] := permute(pp_f,(1,),(3,2))[-1;1 2]*τ[3 2;-4 -2]*bm[1;-3 3]
+    @plansor jiRm[-1 -2;-3 -4] := pp_f[-1;1 2]*τ[1 3;-3 -4]*bm[2;3 -2]
+    @plansor jpiR[-1 -2;-3 -4] := mp_f[-1;1 2]*τ[3 2;-4 -2]*bp[1;-3 3]
+    @plansor ipjR[-1 -2;-3 -4] := permute(pm_f,(1,),(3,2))[-1;1 2]*τ[3 2;-4 -2]*bp[1;-3 3]
+    @plansor jRim[-1 -2;-3 -4] := mp_f[-1;1 2]*τ[1 3;-3 -4]*bm[2;3 -2]
+    @plansor iRjm[-1 -2;-3 -4] := permute(pm_f,(1,),(3,2))[-1;1 2]*τ[1 3;-3 -4]*bm[2;3 -2]
+    @plansor Rpji[-1 -2;-3 -4] := mm_f[-1;1 2]*τ[1 3;-3 -4]*bp[2;3 -2]
+    @plansor pRij[-1 -2;-3 -4] := permute(mm_f,(1,),(3,2))[-1;1 2]*τ[3 2;-4 -2]*bp[1;-3 3]
+    @plansor Rpij[-1 -2;-3 -4] := permute(mm_f,(1,),(3,2))[-1;1 2]*τ[1 3;-3 -4]*bp[2;3 -2]
+    @plansor pRji[-1 -2;-3 -4] := mm_f[-1;1 2]*τ[3 2;-4 -2]*bp[1;-3 3]
+    @plansor kjil[-1 -2;-3 -4] := bp[-1;-3 -2]*Rmap_bp_to_ap[1;2]*conj(mp_f[-4;1 2])
+    @plansor ljik[-1 -2;-3 -4] := bp[-1;-3 -2]*Rmap_bm_to_am[1;2]*conj(pm_f[-4;1 2])
+    @plansor kijl[-1 -2;-3 -4] := bm[-1;-3 -2]*Rmap_bp_to_ap[1;2]*conj(mp_f[-4;1 2])
+    @plansor lijk[-1 -2;-3 -4] := bm[-1;-3 -2]*Rmap_bm_to_am[1;2]*conj(pm_f[-4;1 2])
+    @plansor jikl[-1 -2;-3 -4] := iso_pp[-1;1]*ap[2 -2;3]*τ[1 2;-3 4]*conj(pp_f[-4;4 3])
+    @plansor likj[-1 -2;-3 -4] := iso_pp[-1;1]*am[2 -2;3]*τ[1 2;-3 4]*conj(pm_f[-4;4 3])
+    @plansor jkil[-1 -2;-3 -4] := iso_mm[-1;1]*ap[2 -2;3]*τ[1 2;-3 4]*conj(mp_f[-4;4 3])
+    @plansor lkij[-1 -2;-3 -4] := iso_mm[-1;1]*am[2 -2;3]*τ[1 2;-3 4]*conj(mm_f[-4;4 3])
+    @plansor ijkl[-1 -2;-3 -4] := iso_pp[-1;1]*ap[-3 2;3]*τ[2 1;4 -2]*conj(pp_f[-4;3 4])
+    @plansor ljki[-1 -2;-3 -4] := iso_mm[-1;1]*ap[-3 2;3]*τ[2 1;4 -2]*conj(pm_f[-4;3 4])
+    @plansor ikjl[-1 -2;-3 -4] := iso_pp[-1;1]*am[-3 2;3]*τ[2 1;4 -2]*conj(mp_f[-4;3 4])
+    @plansor lkji[-1 -2;-3 -4] := iso_mm[-1;1]*am[-3 2;3]*τ[2 1;4 -2]*conj(mm_f[-4;3 4])
 
-    for i in 1:basis_size, j in (i + 1):basis_size,
-            k in (j + 1):basis_size, l in (k + 1):basis_size
+    
+    for i in 1:basis_size,j in i+1:basis_size,k in j+1:half_basis_size,l in k+1:basis_size
         # p j i R
-        @plansor pjiR[-1 -2; -3 -4] := ut[-1] * ap[-3 -2; -4]
-        hamdat[k, map_3[2, i, 1, j], map_4[2, l]] += V[k, j, i, l] * pjiR
-
-        # p i j R
-        @plansor pijR[-1 -2; -3 -4] := ut[-1] * ap[-3 -2; -4]
-        hamdat[k, map_3[1, i, 2, j], map_4[2, l]] += V[k, i, j, l] * pijR
-
-        # R j i m
-        @plansor Rjim[-1 -2; -3 -4] := ut[-1] * am[-3 -2; -4]
-        hamdat[k, map_3[2, i, 1, j], map_4[1, l]] += V[l, j, i, k] * Rjim
-
-        # R i j m
-        @plansor Rijm[-1 -2; -3 -4] := ut[-1] * am[-3 -2; -4]
-        hamdat[k, map_3[1, i, 2, j], map_4[1, l]] += V[l, i, j, k] * Rijm
-
         # j p R i
-        @plansor jpRi[-1 -2; -3 -4] := ut[-1] * ap[-3 -2; -4]
-        hamdat[k, map_3[2, i, 1, j], map_4[2, l]] += V[j, k, l, i] * jpRi
-
+        hamdat[k,indmap_2L[2,i,1,j],indmap_1R[2,l]] += (V[j,k,l,i]+V[k,j,i,l])*pjiR
+        # p i j R
         # i p R j
-        @plansor ipRj[-1 -2; -3 -4] := ut[-1] * ap[-3 -2; -4]
-        hamdat[k, map_3[1, i, 2, j], map_4[2, l]] += V[i, k, l, j] * ipRj
-
+        hamdat[k,indmap_2L[1,i,2,j],indmap_1R[2,l]] += (V[i,k,l,j]+V[k,i,j,l])*pijR
+        
+        
+        # R j i m
         # j R m i
-        @plansor jRmi[-1 -2; -3 -4] := ut[-1] * am[-3 -2; -4]
-        hamdat[k, map_3[2, i, 1, j], map_4[1, l]] += V[j, l, k, i] * jRmi
-
+        hamdat[k,indmap_2L[2,i,1,j],indmap_1R[1,l]] += (V[j,l,k,i]+V[l,j,i,k])*Rjim        
+        # R i j m
         # i R m j
-        @plansor iRmj[-1 -2; -3 -4] := ut[-1] * am[-3 -2; -4]
-        hamdat[k, map_3[1, i, 2, j], map_4[1, l]] += V[i, l, k, j] * iRmj
-
+        hamdat[k,indmap_2L[1,i,2,j],indmap_1R[1,l]] += (V[i,l,k,j]+V[l,i,j,k])*Rijm        
+        
+        
+    
         # j i m R
-        @plansor jimR[-1 -2; -3 -4] := pp_f[-1; 1 2] * τ[3 2; -4 -2] * bm[1; -3 3]
-        hamdat[k, map_2[1, i, 1, j], map_4[2, l]] += V[j, i, k, l] * jimR
+        hamdat[k,indmap_2L[1,i,1,j],indmap_1R[2,l]] += V[j,i,k,l]*jimR
+        # i j R m
+        hamdat[k,indmap_2L[1,i,1,j],indmap_1R[2,l]] += V[i,j,l,k]*ijRm
 
         # i j m R
-        @plansor ijmR[-1 -2; -3 -4] := permute(pp_f, (1,), (3, 2))[-1; 1 2] *
-            τ[3 2; -4 -2] * bm[1; -3 3]
-        hamdat[k, map_2[1, i, 1, j], map_4[2, l]] += V[i, j, k, l] * ijmR
-
+        hamdat[k,indmap_2L[1,i,1,j],indmap_1R[2,l]] += V[i,j,k,l]*ijmR
         # j i R m
-        @plansor jiRm[-1 -2; -3 -4] := pp_f[-1; 1 2] * τ[1 3; -3 -4] * bm[2; 3 -2]
-        hamdat[k, map_2[1, i, 1, j], map_4[2, l]] += V[j, i, l, k] * jiRm
-
-        # i j R m
-        @plansor ijRm[-1 -2; -3 -4] := permute(pp_f, (1,), (3, 2))[-1; 1 2] *
-            τ[1 3; -3 -4] * bm[2; 3 -2]
-        hamdat[k, map_2[1, i, 1, j], map_4[2, l]] += V[i, j, l, k] * ijRm
+        hamdat[k,indmap_2L[1,i,1,j],indmap_1R[2,l]] += V[j,i,l,k]*jiRm
 
         # j p i R
-        @plansor jpiR[-1 -2; -3 -4] := mp_f[-1; 1 2] * τ[3 2; -4 -2] * bp[1; -3 3]
-        hamdat[k, map_2[2, i, 1, j], map_4[2, l]] += V[j, k, i, l] * jpiR
+        # p j R i
+        hamdat[k,indmap_2L[2,i,1,j],indmap_1R[2,l]] += (V[k,j,l,i]+V[j,k,i,l])*jpiR
 
         # i p j R
-        @plansor ipjR[-1 -2; -3 -4] := permute(pm_f, (1,), (3, 2))[-1; 1 2] *
-            τ[3 2; -4 -2] * bp[1; -3 3]
-        hamdat[k, map_2[1, i, 2, j], map_4[2, l]] += V[i, k, j, l] * ipjR
+        # p i R j
+        hamdat[k,indmap_2L[1,i,2,j],indmap_1R[2,l]] += (V[k,i,l,j]+V[i,k,j,l])*ipjR
 
         # j R i m
-        @plansor jRim[-1 -2; -3 -4] := mp_f[-1; 1 2] * τ[1 3; -3 -4] * bm[2; 3 -2]
-        hamdat[k, map_2[2, i, 1, j], map_4[1, l]] += V[j, l, i, k] * jRim
+        # R j m i
+        hamdat[k,indmap_2L[2,i,1,j],indmap_1R[1,l]] += (V[l,j,k,i]+V[j,l,i,k])*jRim
 
         # i R j m
-        @plansor iRjm[-1 -2; -3 -4] := permute(pm_f, (1,), (3, 2))[-1; 1 2] *
-            τ[1 3; -3 -4] * bm[2; 3 -2]
-        hamdat[k, map_2[1, i, 2, j], map_4[1, l]] += V[i, l, j, k] * iRjm
-
-        # p j R i
-        @plansor pjRi[-1 -2; -3 -4] := mp_f[-1; 1 2] * τ[3 2; -4 -2] * bp[1; -3 3]
-        hamdat[k, map_2[2, i, 1, j], map_4[2, l]] += V[k, j, l, i] * pjRi
-
-        # p i R j
-        @plansor piRj[-1 -2; -3 -4] := permute(pm_f, (1,), (3, 2))[-1; 1 2] *
-            τ[3 2; -4 -2] * bp[1; -3 3]
-        hamdat[k, map_2[1, i, 2, j], map_4[2, l]] += V[k, i, l, j] * piRj
-
-        # R j m i
-        @plansor Rjmi[-1 -2; -3 -4] := mp_f[-1; 1 2] * τ[1 3; -3 -4] * bm[2; 3 -2]
-        hamdat[k, map_2[2, i, 1, j], map_4[1, l]] += V[l, j, k, i] * Rjmi
-
         # R i m j
-        @plansor Rimj[-1 -2; -3 -4] := permute(pm_f, (1,), (3, 2))[-1; 1 2] *
-            τ[1 3; -3 -4] * bm[2; 3 -2]
-        hamdat[k, map_2[1, i, 2, j], map_4[1, l]] += V[l, i, k, j] * Rimj
-
+        hamdat[k,indmap_2L[1,i,2,j],indmap_1R[1,l]] += (V[l,i,k,j]+V[i,l,j,k])*iRjm
+        
         # R p j i
-        @plansor Rpji[-1 -2; -3 -4] := mm_f[-1; 1 2] * τ[1 3; -3 -4] * bp[2; 3 -2]
-        hamdat[k, map_2[2, i, 2, j], map_4[1, l]] += V[l, k, j, i] * Rpji
+        hamdat[k,indmap_2L[2,i,2,j],indmap_1R[1,l]] += V[l,k,j,i]*Rpji
+        # p R i j
+        hamdat[k,indmap_2L[2,i,2,j],indmap_1R[1,l]] += V[k,l,i,j]*pRij
 
         # R p i j
-        @plansor Rpij[-1 -2; -3 -4] := permute(mm_f, (1,), (3, 2))[-1; 1 2] *
-            τ[1 3; -3 -4] * bp[2; 3 -2]
-        hamdat[k, map_2[2, i, 2, j], map_4[1, l]] += V[l, k, i, j] * Rpij
-
+        hamdat[k,indmap_2L[2,i,2,j],indmap_1R[1,l]] += V[l,k,i,j]*Rpij
         # p R j i
-        @plansor pRji[-1 -2; -3 -4] := mm_f[-1; 1 2] * τ[3 2; -4 -2] * bp[1; -3 3]
-        hamdat[k, map_2[2, i, 2, j], map_4[1, l]] += V[k, l, j, i] * pRji
-
-        # p R i j
-        @plansor pRij[-1 -2; -3 -4] := permute(mm_f, (1,), (3, 2))[-1; 1 2] *
-            τ[3 2; -4 -2] * bp[1; -3 3]
-        hamdat[k, map_2[2, i, 2, j], map_4[1, l]] += V[k, l, i, j] * pRij
+        hamdat[k,indmap_2L[2,i,2,j],indmap_1R[1,l]] += V[k,l,j,i]*pRji
     end
+    
+    
+    for i in 1:basis_size,j in i+1:basis_size,k in j+1:basis_size,l in k+1:basis_size
+        j >= half_basis_size || continue;
 
-    th = MPOHamiltonian(map(x -> x == InitialValue(+) ? missing : x, hamdat))
-    #th = MPOHamiltonian(MPSKit.remove_orphans(th.data));
-    return th + fill(E0 / basis_size, basis_size), (map_1, map_2, map_3, map_4)
+        hamdat[j,indmap_1L[2,i],indmap_2R[1,k,2,l]] += (V[k,j,i,l]+V[j,k,l,i])*kjil
+        hamdat[j,indmap_1L[2,i],indmap_2R[2,k,1,l]] += (V[l,j,i,k]+V[j,l,k,i])*ljik
+        hamdat[j,indmap_1L[1,i],indmap_2R[1,k,2,l]] += (V[k,i,j,l]+V[i,k,l,j])*kijl
+
+        hamdat[j,indmap_1L[1,i],indmap_2R[2,k,1,l]] += (V[l,i,j,k]+V[i,l,k,j])*lijk
+        hamdat[j,indmap_1L[1,i],indmap_2R[2,k,2,l]] += (V[j,i,k,l]+V[i,j,l,k])*jikl
+        hamdat[j,indmap_1L[1,i],indmap_2R[2,k,1,l]] += (V[l,i,k,j]+V[i,l,j,k])*likj
+        hamdat[j,indmap_1L[2,i],indmap_2R[1,k,2,l]] += (V[j,k,i,l]+V[k,j,l,i])*jkil
+        hamdat[j,indmap_1L[2,i],indmap_2R[1,k,1,l]] += (V[l,k,i,j]+V[k,l,j,i])*lkij;
+        hamdat[j,indmap_1L[1,i],indmap_2R[2,k,2,l]] += (V[i,j,k,l]+V[j,i,l,k])*ijkl;
+        hamdat[j,indmap_1L[2,i],indmap_2R[2,k,1,l]] += (V[l,j,k,i]+V[j,l,i,k])*ljki
+        hamdat[j,indmap_1L[1,i],indmap_2R[1,k,2,l]] += (V[i,k,j,l]+V[k,i,l,j])*ikjl
+        hamdat[j,indmap_1L[2,i],indmap_2R[1,k,1,l]] += (V[l,k,j,i]+V[k,l,i,j])*lkji
+    end
+    
+    @plansor kjil[-1 -2;-3 -4] := mp_f[-1;1 2]*Lmap_ap_to_bp[2;1]*ai[-2;-3]*Rmap_bp_to_ap[3;4]*conj(mp_f[-4;3 4])
+    @plansor ljik[-1 -2;-3 -4] := mp_f[-1;1 2]*Lmap_ap_to_bp[2;1]*ai[-2;-3]*Rmap_bm_to_am[3;4]*conj(pm_f[-4;3 4])
+    @plansor kijl[-1 -2;-3 -4] := pm_f[-1;1 2]*Lmap_am_to_bm[2;1]*ai[-2;-3]*Rmap_bp_to_ap[3;4]*conj(mp_f[-4;3 4])
+    @plansor lijk[-1 -2;-3 -4] := pm_f[-1;1 2]*Lmap_am_to_bm[2;1]*ai[-2;-3]*Rmap_bm_to_am[3;4]*conj(pm_f[-4;3 4])
+    @plansor jikl[-1 -2;-3 -4] := pp_f[-1;1 2]*ai[3;-3]*τ[3 1;4 5]*τ[5 2;6 -2]*conj(pp_f[-4;4 6])
+    @plansor likj[-1 -2;-3 -4] := pm_f[-1;1 2]*ai[3;-3]*τ[3 1;4 5]*τ[5 2;6 -2]*conj(pm_f[-4;4 6])
+    @plansor jkil[-1 -2;-3 -4] := mp_f[-1;1 2]*ai[3;-3]*τ[3 1;4 5]*τ[5 2;6 -2]*conj(mp_f[-4;4 6])
+    @plansor lkij[-1 -2;-3 -4] := mm_f[-1;1 2]*ai[3;-3]*τ[3 1;4 5]*τ[5 2;6 -2]*conj(mm_f[-4;4 6])
+    @plansor ijkl[-1 -2;-3 -4] := pp_f[-1;7 8]*τ[7 8;1 2]*ai[3;-3]*τ[3 1;4 5]*τ[5 2;6 -2]*conj(pp_f[-4;4 6])
+    @plansor ljki[-1 -2;-3 -4] := mp_f[-1;7 8]*τ[7 8;1 2]*ai[3;-3]*τ[3 1;4 5]*τ[5 2;6 -2]*conj(pm_f[-4;4 6])
+    @plansor ikjl[-1 -2;-3 -4] := pm_f[-1;7 8]*τ[7 8;1 2]*ai[3;-3]*τ[3 1;4 5]*τ[5 2;6 -2]*conj(mp_f[-4;4 6])
+    @plansor lkji[-1 -2;-3 -4] := mm_f[-1;7 8]*τ[7 8;1 2]*ai[3;-3]*τ[3 1;4 5]*τ[5 2;6 -2]*conj(mm_f[-4;4 6])
+        
+    for i in 1:half_basis_size-1,j in i+1:half_basis_size-1,k in half_basis_size+1:basis_size,l in k+1:basis_size
+        
+        # k j i l
+        # j k l i
+        hamdat[half_basis_size,indmap_2L[2,i,1,j],indmap_2R[1,k,2,l]] += (V[k,j,i,l]+V[j,k,l,i])*kjil
+        
+        # l j i k
+        # j l k i
+        hamdat[half_basis_size,indmap_2L[2,i,1,j],indmap_2R[2,k,1,l]] += (V[l,j,i,k]+V[j,l,k,i])*ljik
+        
+        # k i j l
+        # i k l j
+        hamdat[half_basis_size,indmap_2L[1,i,2,j],indmap_2R[1,k,2,l]] += (V[k,i,j,l]+V[i,k,l,j])*kijl
+
+        # l i j k
+        # i l k j
+        hamdat[half_basis_size,indmap_2L[1,i,2,j],indmap_2R[2,k,1,l]] += (V[l,i,j,k]+V[i,l,k,j])*lijk
+        
+        # j i k l
+        # i j l k
+        hamdat[half_basis_size,indmap_2L[1,i,1,j],indmap_2R[2,k,2,l]] += (V[j,i,k,l]+V[i,j,l,k])*jikl
+        
+        # l i k j
+        # i l j k
+        hamdat[half_basis_size,indmap_2L[1,i,2,j],indmap_2R[2,k,1,l]] += (V[l,i,k,j]+V[i,l,j,k])*likj
+
+        # j k i l
+        # k j l i
+        hamdat[half_basis_size,indmap_2L[2,i,1,j],indmap_2R[1,k,2,l]] += (V[j,k,i,l]+V[k,j,l,i])*jkil
+
+        # l k i j
+        # k l j i
+        hamdat[half_basis_size,indmap_2L[2,i,2,j],indmap_2R[1,k,1,l]] += (V[l,k,i,j]+V[k,l,j,i])*lkij
+
+        # i j k l
+        # j i l k
+        hamdat[half_basis_size,indmap_2L[1,i,1,j],indmap_2R[2,k,2,l]] += (V[i,j,k,l]+V[j,i,l,k])*ijkl
+        
+        # l j k i
+        # j l i k
+        hamdat[half_basis_size,indmap_2L[2,i,1,j],indmap_2R[2,k,1,l]] += (V[l,j,k,i]+V[j,l,i,k])*ljki
+        
+        # i k j l
+        # k i l j
+        hamdat[half_basis_size,indmap_2L[1,i,2,j],indmap_2R[1,k,2,l]] += (V[i,k,j,l]+V[k,i,l,j])*ikjl
+        
+        # l k j i
+        # k l i j
+        hamdat[half_basis_size,indmap_2L[2,i,2,j],indmap_2R[1,k,1,l]] += (V[l,k,j,i]+V[k,l,i,j])*lkji
+        
+    end
+    
+    
+    map!(x->x == EmptyVal() ? Elt(0) : x,hamdat,hamdat);
+    th = MPOHamiltonian(convert(Array{Union{Elt,typeof(ut_ap)},3},hamdat));
+
+    @show half_basis_size
+    th+fill(Elt(E0)/basis_size,basis_size),
+        (indmap_1L, indmap_1R, indmap_2L, indmap_2R)
 end
+
+

--- a/src/models/quantum_chemistry.jl
+++ b/src/models/quantum_chemistry.jl
@@ -806,9 +806,9 @@ function mapped_quantum_chemistry_hamiltonian(E0, K, V, Elt = ComplexF64)
 
 
     map!(x -> x == EmptyVal() ? Elt(0) : x, hamdat, hamdat)
+    # TODO constructor errors: no signature
     th = MPOHamiltonian(convert(Array{Union{Elt, typeof(ut_ap)}, 3}, hamdat))
 
-    @show half_basis_size
     return th + fill(Elt(E0) / basis_size, basis_size),
         (indmap_1L, indmap_1R, indmap_2L, indmap_2R)
 end

--- a/src/models/quantum_chemistry.jl
+++ b/src/models/quantum_chemistry.jl
@@ -1,807 +1,814 @@
-struct EmptyVal
+struct EmptyVal end
+
+Base.:+(::EmptyVal, ::EmptyVal) = EmptyVal();
+Base.:+(::EmptyVal, v) = v
+Base.:+(v, ::EmptyVal) = v
+
+Base.:-(::EmptyVal, ::EmptyVal) = EmptyVal();
+Base.:-(::EmptyVal, v) = -v
+Base.:-(v, ::EmptyVal) = v
+
+Base.:*(::EmptyVal, ::EmptyVal) = EmptyVal()
+Base.:*(::EmptyVal, _) = EmptyVal()
+Base.:*(_, ::EmptyVal) = EmptyVal()
+
+"""
+    quantum_chemistry_hamiltonian(E0::Number, K::AbstractMatrix{<:Number}, V::AbstractArray{<:Number,4}, [elt::Type{<:Number}=ComplexF64])
+
+MPO for the quantum chemistry Hamiltonian, with kinetic energy ``K`` and potential energy ``V``. The Hamiltonian is given by
+
+```math
+H = E0 + \\sum_{i,j} \\sum_s K[i,j] e_{i,s}^{+} e_{j,s}^{-} + \\sum_{i,j,k,l} \\sum_{s,t} V[i,j,k,l] e_{i,s}^{+} e_{j,t}^{+} e_{k,t}^{-} e_{l,s}^{-}
+```
+
+where ``s`` and ``t`` are spin indices, which can be ``\\uparrow`` or ``\\downarrow``. The full hamiltonian has `U₁ ⊠ SU₂ ⊠ FermionParity` symmetry.
+
+!!! note
+    This should not be regarded as state-of-the-art quantum chemistry DMRG code. It is only meant to demonstrate the use of MPSKit for quantum chemistry. In particular:
+    - No attempt was made to incorporate spacegroup symmetries
+    - MPSKit does not contain many required algorithms in quantum chemistry (orbital ordering/optimization)
+    - MPOHamiltonian is not well suited for quantum chemistry
+"""
+function quantum_chemistry_hamiltonian(E0, K, V, Elt = ComplexF64)
+    return mapped_quantum_chemistry_hamiltonian(E0, K, V, Elt)[1]
 end
 
-Base.:+(::EmptyVal,::EmptyVal) = EmptyVal();
-Base.:+(::EmptyVal,v) = v
-Base.:+(v,::EmptyVal) = v
+function mapped_quantum_chemistry_hamiltonian(E0, K, V, Elt = ComplexF64)
+    basis_size = size(K, 1)
+    half_basis_size = Int(ceil(basis_size / 2))
 
-Base.:-(::EmptyVal,::EmptyVal) = EmptyVal();
-Base.:-(::EmptyVal,v) = -v
-Base.:-(v,::EmptyVal) = v
-
-
-Base.:*(::EmptyVal,::EmptyVal) = EmptyVal()
-Base.:*(::EmptyVal,_) = EmptyVal()
-Base.:*(_,::EmptyVal) = EmptyVal()
-"""
-    Implements
-    
-    H = E0 + ∑ᵢⱼ ∑ₛ K[i,j] c^{s,+}_i c^{s,-}_j + ∑ᵢⱼₖₗ ∑ₛₜ V[i,j,k,l] c^{s,+}_i c^{t,+}_j c^{t,-}_k c^{s,-}_l
-
-    where s and t are spin indices, which can be up or down. The full hamiltonian has U₁ × SU₂ × FermionParity symmetry.
-
-    This should not be regarded as a state of the art qchem-dmrg code! 
-        - No attempt was made to incorporate spacegroup symmetries
-        - MPSKit does not contain many required algorithms in qchem (orbital ordering/optimization)
-        - MPOHamiltonian is not well suited for quantum chemistry
-"""
-quantum_chemistry_hamiltonian(E0,K,V,Elt=ComplexF64) = mapped_quantum_chemistry_hamiltonian(E0,K,V,Elt)[1]
-
-function mapped_quantum_chemistry_hamiltonian(E0,K,V,Elt=ComplexF64)
-    basis_size = size(K,1);
-    half_basis_size = Int(ceil(basis_size/2));
-    
     # the phsyical space
-    psp = Vect[(Irrep[U₁]⊠Irrep[SU₂] ⊠ FermionParity)]((0,0,0)=>1, (1,1//2,1)=>1, (2,0,0)=>1);
+    psp = Vect[(U1Irrep ⊠ SU2Irrep ⊠ FermionParity)](
+        (0, 0, 0) => 1,
+        (1, 1 // 2, 1) => 1,
+        (2, 0, 0) => 1
+    )
 
-    ap = TensorMap(ones,Elt,psp*Vect[(Irrep[U₁]⊠Irrep[SU₂] ⊠ FermionParity)]((-1,1//2,1)=>1),psp);
-    blocks(ap)[(U₁(0)⊠SU₂(0)⊠FermionParity(0))] .*= -sqrt(2);
-    blocks(ap)[(U₁(1)⊠SU₂(1//2)⊠FermionParity(1))]  .*= 1;
+    ap = ones(
+        Elt,
+        psp * Vect[(U1Irrep ⊠ SU2Irrep ⊠ FermionParity)]((-1, 1 // 2, 1) => 1),
+        psp
+    )
+    block(ap, U1Irrep(0) ⊠ SU2Irrep(0) ⊠ FermionParity(0)) .*= -sqrt(2)
+    block(ap, U1Irrep(1) ⊠ SU2Irrep(1 // 2) ⊠ FermionParity(1)) .*= 1
 
 
-    bm = TensorMap(ones,Elt,psp,Vect[(Irrep[U₁]⊠Irrep[SU₂]⊠FermionParity)]((-1,1//2,1)=>1)*psp);
-    blocks(bm)[(U₁(0)⊠SU₂(0)⊠FermionParity(0))] .*= sqrt(2);
-    blocks(bm)[(U₁(1)⊠SU₂(1//2)⊠FermionParity(1))] .*= -1;
+    bm = ones(Elt, psp, Vect[(U1Irrep ⊠ SU2Irrep ⊠ FermionParity)]((-1, 1 // 2, 1) => 1) * psp)
+    block(bm, U1Irrep(0) ⊠ SU2Irrep(0) ⊠ FermionParity(0)) .*= sqrt(2)
+    block(bm, U1Irrep(1) ⊠ SU2Irrep(1 // 2) ⊠ FermionParity(1)) .*= -1
 
     # this transposition is easier to reason about in a planar way
-    am = transpose(ap',(2,1),(3,));
-    bp = transpose(bm',(1,),(3,2));
-    ap = transpose(ap,(3,1),(2,));
-    bm = transpose(bm,(2,),(3,1));
-    
-    @plansor b_derp[-1 -2;-3] := bp[1;2 -2]*τ[-3 -1;2 1]
-    Lmap_ap_to_bp = inv(ap'*ap)*ap'*b_derp;
-    @assert norm(ap*Lmap_ap_to_bp-b_derp) < 1e-12;
-    @plansor b_derp[-1 -2;-3] := bm[1;2 -2]*τ[-3 -1;2 1]
-    Lmap_am_to_bm = inv(am'*am)*am'*b_derp;
-    @assert norm(am*Lmap_am_to_bm-b_derp) < 1e-12;
+    am = transpose(ap', ((2, 1), (3,)))
+    bp = transpose(bm', ((1,), (3, 2)))
+    ap = transpose(ap, ((3, 1), (2,)))
+    bm = transpose(bm, ((2,), (3, 1)))
 
-    Rmap_bp_to_ap = transpose(Lmap_am_to_bm',(2,),(1,));
-    Rmap_bm_to_am = transpose(Lmap_ap_to_bp',(2,),(1,));
-    @plansor a_derp[-1 -2;-3] := bp[1;-1 2]*Rmap_bp_to_ap[1;3]*τ[2 3;-3 -2]
-    @assert norm(a_derp-ap) < 1e-12
-    @plansor a_derp[-1 -2;-3] := bm[1;-1 2]*Rmap_bm_to_am[1;3]*τ[2 3;-3 -2]
-    @assert norm(a_derp-am) < 1e-12
+    @plansor b_derp[-1 -2;-3] := bp[1;2 -2] * τ[-3 -1;2 1]
+    Lmap_ap_to_bp = inv(ap' * ap) * ap' * b_derp
+    @assert norm(ap * Lmap_ap_to_bp - b_derp) < 1.0e-12
+    @plansor b_derp[-1 -2;-3] := bm[1;2 -2] * τ[-3 -1;2 1]
+    Lmap_am_to_bm = inv(am' * am) * am' * b_derp
+    @assert norm(am * Lmap_am_to_bm - b_derp) < 1.0e-12
 
-    h_pm = TensorMap(ones,Elt,psp,psp);
-    blocks(h_pm)[(U₁(0)⊠SU₂(0)⊠ FermionParity(0))] .=0;
-    blocks(h_pm)[(U₁(1)⊠SU₂(1//2)⊠ FermionParity(1))] .=1;
-    blocks(h_pm)[(U₁(2)⊠SU₂(0)⊠ FermionParity(0))] .=2;
+    Rmap_bp_to_ap = transpose(Lmap_am_to_bm', ((2,), (1,)))
+    Rmap_bm_to_am = transpose(Lmap_ap_to_bp', ((2,), (1,)))
+    @plansor a_derp[-1 -2;-3] := bp[1;-1 2] * Rmap_bp_to_ap[1;3] * τ[2 3;-3 -2]
+    @assert norm(a_derp - ap) < 1.0e-12
+    @plansor a_derp[-1 -2;-3] := bm[1;-1 2] * Rmap_bm_to_am[1;3] * τ[2 3;-3 -2]
+    @assert norm(a_derp - am) < 1.0e-12
 
-    @plansor o_derp[-1 -2;-3 -4] := am[-1 1;-3]*ap[1 -2;-4]
-    h_pm_derp = transpose(h_pm,(2,1),());
-    Lmap_apam_to_pm = inv(o_derp'*o_derp)*o_derp'*h_pm_derp;
-    @assert norm(o_derp*Lmap_apam_to_pm-h_pm_derp) <1e-12;
+    h_pm = ones(Elt, psp, psp)
+    block(h_pm, U1Irrep(0) ⊠ SU2Irrep(0) ⊠ FermionParity(0)) .= 0
+    block(h_pm, U1Irrep(1) ⊠ SU2Irrep(1 // 2) ⊠ FermionParity(1)) .= 1
+    block(h_pm, U1Irrep(2) ⊠ SU2Irrep(0) ⊠ FermionParity(0)) .= 2
 
-    @plansor o_derp[-1 -2;-3 -4] := bm[-1;-3 1]*bp[-2;1 -4]
-    h_pm_derp2 = transpose(h_pm,(),(2,1));
-    Rmap_bpbm_to_pm = h_pm_derp2*o_derp'*inv(o_derp*o_derp');
-    @assert norm(transpose(h_pm,(),(2,1))-Rmap_bpbm_to_pm*o_derp) < 1e-12
-    
-    h_ppmm = h_pm*h_pm-h_pm;
+    @plansor o_derp[-1 -2;-3 -4] := am[-1 1;-3] * ap[1 -2;-4]
+    h_pm_derp = transpose(h_pm, ((2, 1), ()))
+    Lmap_apam_to_pm = inv(o_derp' * o_derp) * o_derp' * h_pm_derp
+    @assert norm(o_derp * Lmap_apam_to_pm - h_pm_derp) < 1.0e-12
 
-    ai = isomorphism(storagetype(ap),psp,psp);
+    @plansor o_derp[-1 -2;-3 -4] := bm[-1;-3 1] * bp[-2;1 -4]
+    h_pm_derp2 = transpose(h_pm, ((), (2, 1)))
+    Rmap_bpbm_to_pm = h_pm_derp2 * o_derp' * inv(o_derp * o_derp')
+    @assert norm(transpose(h_pm, ((), (2, 1))) - Rmap_bpbm_to_pm * o_derp) < 1.0e-12
+
+    h_ppmm = h_pm * h_pm - h_pm
+
+    ai = isomorphism(storagetype(ap), psp, psp)
     # ----------------------------------------------------------------------
     # Maps something easier to understand to the corresponding virtual index
     # ----------------------------------------------------------------------
 
-    cnt = 1;
-    indmap_1L = fill(0,2,basis_size);
+    cnt = 1
+    indmap_1L = fill(0, 2, basis_size)
     for i in 1:2, j in 1:basis_size
         cnt += 1
-        indmap_1L[i,j] = cnt;
+        indmap_1L[i, j] = cnt
     end
 
-    indmap_1R = fill(0,2,basis_size);
+    indmap_1R = fill(0, 2, basis_size)
     for i in 1:2, j in 1:basis_size
         cnt += 1
-        indmap_1R[i,j] = cnt;
+        indmap_1R[i, j] = cnt
     end
 
-    indmap_2L = fill(0,2,basis_size,2,basis_size);
-    indmap_2R = fill(0,2,basis_size,2,basis_size);
+    indmap_2L = fill(0, 2, basis_size, 2, basis_size)
+    indmap_2R = fill(0, 2, basis_size, 2, basis_size)
     for pm1 in 1:2, i in 1:half_basis_size, pm2 in 1:2, j in i:half_basis_size
         cnt += 1
-        indmap_2L[pm1,i,pm2,j] = cnt;
-        indmap_2R[pm1,end-j+1,pm2,end-i+1] = cnt
+        indmap_2L[pm1, i, pm2, j] = cnt
+        indmap_2R[pm1, end - j + 1, pm2, end - i + 1] = cnt
     end
-    
-    hamdat = convert(Array{Any,3},fill(EmptyVal(),basis_size,cnt+1,cnt+1));#Array{Any,3}(missing,basis_size,cnt+2,cnt+2);
-    hamdat[:,1,1].+= Elt(1);
-    hamdat[:,end,end].+= Elt(1);
-    
+
+    hamdat = convert(Array{Any, 3}, fill(EmptyVal(), basis_size, cnt + 1, cnt + 1)) #Array{Any,3}(missing,basis_size,cnt+2,cnt+2);
+    hamdat[:, 1, 1] .+= Elt(1)
+    hamdat[:, end, end] .+= Elt(1)
+
     # pure onsite interactions:
     for i in 1:basis_size
         # onsite kinetic part
-        hamdat[i,1,end] += K[i,i]*add_util_leg(h_pm);
+        hamdat[i, 1, end] += K[i, i] * add_util_leg(h_pm)
 
         # onsite electronic part
-        hamdat[i,1,end] += V[i,i,i,i]*add_util_leg(h_ppmm);
+        hamdat[i, 1, end] += V[i, i, i, i] * add_util_leg(h_ppmm)
     end
-    
-    
+
+
     # fill indmap_1L and indmap_1R
-    ut = Tensor(ones,oneunit(psp));
-    @plansor ut_ap[-1 -2;-3 -4] := ut[-1]*ap[-3 -2;-4];
-    @plansor ut_am[-1 -2;-3 -4] := ut[-1]*am[-3 -2;-4];
-    @plansor bp_ut[-1 -2;-3 -4] := bp[-1;-3 -2]*conj(ut[-4]);
-    @plansor bm_ut[-1 -2;-3 -4] := bm[-1;-3 -2]*conj(ut[-4]);
+    ut = ones(oneunit(psp))
+    @plansor ut_ap[-1 -2;-3 -4] := ut[-1] * ap[-3 -2;-4]
+    @plansor ut_am[-1 -2;-3 -4] := ut[-1] * am[-3 -2;-4]
+    @plansor bp_ut[-1 -2;-3 -4] := bp[-1;-3 -2] * conj(ut[-4])
+    @plansor bm_ut[-1 -2;-3 -4] := bm[-1;-3 -2] * conj(ut[-4])
     for i in 1:basis_size
-        hamdat[i,1,indmap_1L[1,i]] += ut_ap;
-        hamdat[i,1,indmap_1L[2,i]] += ut_am;
-        
-        hamdat[i,indmap_1R[1,i],end] += bp_ut
-        hamdat[i,indmap_1R[2,i],end] += bm_ut
-        
-        for loc in i+1:basis_size
-            hamdat[loc,indmap_1L[1,i],indmap_1L[1,i]] = Elt(1)
-            hamdat[loc,indmap_1L[2,i],indmap_1L[2,i]] = Elt(1)
+        hamdat[i, 1, indmap_1L[1, i]] += ut_ap
+        hamdat[i, 1, indmap_1L[2, i]] += ut_am
+
+        hamdat[i, indmap_1R[1, i], end] += bp_ut
+        hamdat[i, indmap_1R[2, i], end] += bm_ut
+
+        for loc in (i + 1):basis_size
+            hamdat[loc, indmap_1L[1, i], indmap_1L[1, i]] = Elt(1)
+            hamdat[loc, indmap_1L[2, i], indmap_1L[2, i]] = Elt(1)
         end
 
-        for loc in 1:i-1
-            hamdat[loc,indmap_1R[1,i],indmap_1R[1,i]] = Elt(1)
-            hamdat[loc,indmap_1R[2,i],indmap_1R[2,i]] = Elt(1)
+        for loc in 1:(i - 1)
+            hamdat[loc, indmap_1R[1, i], indmap_1R[1, i]] = Elt(1)
+            hamdat[loc, indmap_1R[2, i], indmap_1R[2, i]] = Elt(1)
         end
     end
 
     # indmap_2 onsite part
     # we need pp, mm, pm
-    pp_f = isometry(fuse(_lastspace(ap)'*_lastspace(ap)'),_lastspace(ap)'*_lastspace(ap)');
-    mm_f = isometry(fuse(_lastspace(am)'*_lastspace(am)'),_lastspace(am)'*_lastspace(am)');
-    mp_f = isometry(fuse(_lastspace(am)'*_lastspace(ap)'),_lastspace(am)'*_lastspace(ap)');
-    pm_f = isometry(fuse(_lastspace(ap)'*_lastspace(am)'),_lastspace(ap)'*_lastspace(am)');
+    pp_f = isometry(fuse(MPSKit._lastspace(ap)' ⊗ MPSKit._lastspace(ap)'), MPSKit._lastspace(ap)' ⊗ MPSKit._lastspace(ap)')
+    mm_f = isometry(fuse(MPSKit._lastspace(am)' ⊗ MPSKit._lastspace(am)'), MPSKit._lastspace(am)' ⊗ MPSKit._lastspace(am)')
+    mp_f = isometry(fuse(MPSKit._lastspace(am)' ⊗ MPSKit._lastspace(ap)'), MPSKit._lastspace(am)' ⊗ MPSKit._lastspace(ap)')
+    pm_f = isometry(fuse(MPSKit._lastspace(ap)' ⊗ MPSKit._lastspace(am)'), MPSKit._lastspace(ap)' ⊗ MPSKit._lastspace(am)')
 
 
-    @plansor ut_apap[-1 -2;-3 -4] := ut[-1]*ap[-3 1;3]*ap[1 -2;4]*conj(pp_f[-4;3 4]);
-    @plansor ut_amam[-1 -2;-3 -4] := ut[-1]*am[-3 1;3]*am[1 -2;4]*conj(mm_f[-4;3 4]);
-    @plansor ut_amap[-1 -2;-3 -4] := ut[-1]*am[-3 1;3]*ap[1 -2;4]*conj(mp_f[-4;3 4]);
-    @plansor ut_apam[-1 -2;-3 -4] := ut[-1]*ap[-3 1;3]*am[1 -2;4]*conj(pm_f[-4;3 4]);
+    @plansor ut_apap[-1 -2;-3 -4] := ut[-1] * ap[-3 1;3] * ap[1 -2;4] * conj(pp_f[-4;3 4])
+    @plansor ut_amam[-1 -2;-3 -4] := ut[-1] * am[-3 1;3] * am[1 -2;4] * conj(mm_f[-4;3 4])
+    @plansor ut_amap[-1 -2;-3 -4] := ut[-1] * am[-3 1;3] * ap[1 -2;4] * conj(mp_f[-4;3 4])
+    @plansor ut_apam[-1 -2;-3 -4] := ut[-1] * ap[-3 1;3] * am[1 -2;4] * conj(pm_f[-4;3 4])
 
-    @plansor bpbp_ut[-1 -2;-3 -4] := mm_f[-1;1 2]*bp[1;-3 3]*bp[2;3 -2]*conj(ut[-4]);
-    @plansor bmbm_ut[-1 -2;-3 -4] := pp_f[-1;1 2]*bm[1;-3 3]*bm[2;3 -2]*conj(ut[-4]);
-    @plansor bmbp_ut[-1 -2;-3 -4] := pm_f[-1;1 2]*bm[1;-3 3]*bp[2;3 -2]*conj(ut[-4]);
-    @plansor bpbm_ut[-1 -2;-3 -4] := mp_f[-1;1 2]*bp[1;-3 3]*bm[2;3 -2]*conj(ut[-4]);
-    
+    @plansor bpbp_ut[-1 -2;-3 -4] := mm_f[-1;1 2] * bp[1;-3 3] * bp[2;3 -2] * conj(ut[-4])
+    @plansor bmbm_ut[-1 -2;-3 -4] := pp_f[-1;1 2] * bm[1;-3 3] * bm[2;3 -2] * conj(ut[-4])
+    @plansor bmbp_ut[-1 -2;-3 -4] := pm_f[-1;1 2] * bm[1;-3 3] * bp[2;3 -2] * conj(ut[-4])
+    @plansor bpbm_ut[-1 -2;-3 -4] := mp_f[-1;1 2] * bp[1;-3 3] * bm[2;3 -2] * conj(ut[-4])
+
     for i in 1:basis_size
-        if i<half_basis_size
-            hamdat[i,1,indmap_2L[1,i,1,i]] += ut_apap;
-            hamdat[i,1,indmap_2L[2,i,1,i]] += ut_amap;
-            hamdat[i,1,indmap_2L[1,i,2,i]] += ut_apam;
-            hamdat[i,1,indmap_2L[2,i,2,i]] += ut_amam;
-            for loc in i+1:half_basis_size-1
-                hamdat[loc,indmap_2L[1,i,1,i],indmap_2L[1,i,1,i]] = Elt(1);
-                hamdat[loc,indmap_2L[2,i,1,i],indmap_2L[2,i,1,i]] = Elt(1);
-                hamdat[loc,indmap_2L[1,i,2,i],indmap_2L[1,i,2,i]] = Elt(1);
-                hamdat[loc,indmap_2L[2,i,2,i],indmap_2L[2,i,2,i]] = Elt(1);
+        if i < half_basis_size
+            hamdat[i, 1, indmap_2L[1, i, 1, i]] += ut_apap
+            hamdat[i, 1, indmap_2L[2, i, 1, i]] += ut_amap
+            hamdat[i, 1, indmap_2L[1, i, 2, i]] += ut_apam
+            hamdat[i, 1, indmap_2L[2, i, 2, i]] += ut_amam
+            for loc in (i + 1):(half_basis_size - 1)
+                hamdat[loc, indmap_2L[1, i, 1, i], indmap_2L[1, i, 1, i]] = Elt(1)
+                hamdat[loc, indmap_2L[2, i, 1, i], indmap_2L[2, i, 1, i]] = Elt(1)
+                hamdat[loc, indmap_2L[1, i, 2, i], indmap_2L[1, i, 2, i]] = Elt(1)
+                hamdat[loc, indmap_2L[2, i, 2, i], indmap_2L[2, i, 2, i]] = Elt(1)
             end
         elseif i > half_basis_size
-            hamdat[i,indmap_2R[1,i,1,i],end] += bpbp_ut;
-            hamdat[i,indmap_2R[2,i,1,i],end] += bmbp_ut;
-            hamdat[i,indmap_2R[1,i,2,i],end] += bpbm_ut;
-            hamdat[i,indmap_2R[2,i,2,i],end] += bmbm_ut;
-            for loc in half_basis_size+1:i-1
-                hamdat[loc,indmap_2R[1,i,1,i],indmap_2R[1,i,1,i]] = Elt(1);
-                hamdat[loc,indmap_2R[2,i,1,i],indmap_2R[2,i,1,i]] = Elt(1);
-                hamdat[loc,indmap_2R[1,i,2,i],indmap_2R[1,i,2,i]] = Elt(1);
-                hamdat[loc,indmap_2R[2,i,2,i],indmap_2R[2,i,2,i]] = Elt(1);
+            hamdat[i, indmap_2R[1, i, 1, i], end] += bpbp_ut
+            hamdat[i, indmap_2R[2, i, 1, i], end] += bmbp_ut
+            hamdat[i, indmap_2R[1, i, 2, i], end] += bpbm_ut
+            hamdat[i, indmap_2R[2, i, 2, i], end] += bmbm_ut
+            for loc in (half_basis_size + 1):(i - 1)
+                hamdat[loc, indmap_2R[1, i, 1, i], indmap_2R[1, i, 1, i]] = Elt(1)
+                hamdat[loc, indmap_2R[2, i, 1, i], indmap_2R[2, i, 1, i]] = Elt(1)
+                hamdat[loc, indmap_2R[1, i, 2, i], indmap_2R[1, i, 2, i]] = Elt(1)
+                hamdat[loc, indmap_2R[2, i, 2, i], indmap_2R[2, i, 2, i]] = Elt(1)
             end
         end
     end
 
     # indmap_2 disconnected part
-    iso_pp = isomorphism(_lastspace(ap)',_lastspace(ap)');
-    iso_mm = isomorphism(_lastspace(am)',_lastspace(am)');
+    iso_pp = isomorphism(MPSKit._lastspace(ap)', MPSKit._lastspace(ap)')
+    iso_mm = isomorphism(MPSKit._lastspace(am)', MPSKit._lastspace(am)')
 
-    @plansor p_ap[-1 -2;-3 -4] := iso_pp[-1;1]*τ[1 2;-3 3]*ap[2 -2;4]*conj(pp_f[-4;3 4]);
-    @plansor m_ap[-1 -2;-3 -4] := iso_mm[-1;1]*τ[1 2;-3 3]*ap[2 -2;4]*conj(mp_f[-4;3 4]);
-    @plansor p_am[-1 -2;-3 -4] := iso_pp[-1;1]*τ[1 2;-3 3]*am[2 -2;4]*conj(pm_f[-4;3 4]);
-    @plansor m_am[-1 -2;-3 -4] := iso_mm[-1;1]*τ[1 2;-3 3]*am[2 -2;4]*conj(mm_f[-4;3 4]);
+    @plansor p_ap[-1 -2;-3 -4] := iso_pp[-1;1] * τ[1 2;-3 3] * ap[2 -2;4] * conj(pp_f[-4;3 4])
+    @plansor m_ap[-1 -2;-3 -4] := iso_mm[-1;1] * τ[1 2;-3 3] * ap[2 -2;4] * conj(mp_f[-4;3 4])
+    @plansor p_am[-1 -2;-3 -4] := iso_pp[-1;1] * τ[1 2;-3 3] * am[2 -2;4] * conj(pm_f[-4;3 4])
+    @plansor m_am[-1 -2;-3 -4] := iso_mm[-1;1] * τ[1 2;-3 3] * am[2 -2;4] * conj(mm_f[-4;3 4])
 
-    @plansor bp_p[-1 -2;-3 -4] := bp[2;-3 3]*iso_mm[1;-4]*τ[4 -2;3 1]*mm_f[-1;2 4]
-    @plansor bm_p[-1 -2;-3 -4] := bm[2;-3 3]*iso_mm[1;-4]*τ[4 -2;3 1]*pm_f[-1;2 4]
-    @plansor bm_m[-1 -2;-3 -4] := bm[2;-3 3]*iso_pp[1;-4]*τ[4 -2;3 1]*pp_f[-1;2 4]
-    @plansor bp_m[-1 -2;-3 -4] := bp[2;-3 3]*iso_pp[1;-4]*τ[4 -2;3 1]*mp_f[-1;2 4]
+    @plansor bp_p[-1 -2;-3 -4] := bp[2;-3 3] * iso_mm[1;-4] * τ[4 -2;3 1] * mm_f[-1;2 4]
+    @plansor bm_p[-1 -2;-3 -4] := bm[2;-3 3] * iso_mm[1;-4] * τ[4 -2;3 1] * pm_f[-1;2 4]
+    @plansor bm_m[-1 -2;-3 -4] := bm[2;-3 3] * iso_pp[1;-4] * τ[4 -2;3 1] * pp_f[-1;2 4]
+    @plansor bp_m[-1 -2;-3 -4] := bp[2;-3 3] * iso_pp[1;-4] * τ[4 -2;3 1] * mp_f[-1;2 4]
 
-    for i in 1:basis_size, j in i+1:basis_size
-        if j<half_basis_size
-            hamdat[j,indmap_1L[1,i],indmap_2L[1,i,1,j]] += p_ap;
-            hamdat[j,indmap_1L[1,i],indmap_2L[1,i,2,j]] += p_am;
-            hamdat[j,indmap_1L[2,i],indmap_2L[2,i,1,j]] += m_ap;
-            hamdat[j,indmap_1L[2,i],indmap_2L[2,i,2,j]] += m_am;
-            for k in j+1:half_basis_size-1
-                hamdat[k,indmap_2L[1,i,1,j],indmap_2L[1,i,1,j]] = Elt(1);
-                hamdat[k,indmap_2L[1,i,2,j],indmap_2L[1,i,2,j]] = Elt(1);
-                hamdat[k,indmap_2L[2,i,2,j],indmap_2L[2,i,2,j]] = Elt(1);
-                hamdat[k,indmap_2L[2,i,1,j],indmap_2L[2,i,1,j]] = Elt(1);
+    for i in 1:basis_size, j in (i + 1):basis_size
+        if j < half_basis_size
+            hamdat[j, indmap_1L[1, i], indmap_2L[1, i, 1, j]] += p_ap
+            hamdat[j, indmap_1L[1, i], indmap_2L[1, i, 2, j]] += p_am
+            hamdat[j, indmap_1L[2, i], indmap_2L[2, i, 1, j]] += m_ap
+            hamdat[j, indmap_1L[2, i], indmap_2L[2, i, 2, j]] += m_am
+            for k in (j + 1):(half_basis_size - 1)
+                hamdat[k, indmap_2L[1, i, 1, j], indmap_2L[1, i, 1, j]] = Elt(1)
+                hamdat[k, indmap_2L[1, i, 2, j], indmap_2L[1, i, 2, j]] = Elt(1)
+                hamdat[k, indmap_2L[2, i, 2, j], indmap_2L[2, i, 2, j]] = Elt(1)
+                hamdat[k, indmap_2L[2, i, 1, j], indmap_2L[2, i, 1, j]] = Elt(1)
             end
         end
 
         if i > half_basis_size
-            hamdat[i,indmap_2R[1,i,1,j],indmap_1R[1,j]] += bp_p;
-            hamdat[i,indmap_2R[1,i,2,j],indmap_1R[2,j]] += bp_m;
-            hamdat[i,indmap_2R[2,i,1,j],indmap_1R[1,j]] += bm_p;
-            hamdat[i,indmap_2R[2,i,2,j],indmap_1R[2,j]] += bm_m;
-            for k in half_basis_size+1:i-1
-                hamdat[k,indmap_2R[1,i,1,j],indmap_2R[1,i,1,j]] = Elt(1);
-                hamdat[k,indmap_2R[1,i,2,j],indmap_2R[1,i,2,j]] = Elt(1);
-                hamdat[k,indmap_2R[2,i,2,j],indmap_2R[2,i,2,j]] = Elt(1);
-                hamdat[k,indmap_2R[2,i,1,j],indmap_2R[2,i,1,j]] = Elt(1);
+            hamdat[i, indmap_2R[1, i, 1, j], indmap_1R[1, j]] += bp_p
+            hamdat[i, indmap_2R[1, i, 2, j], indmap_1R[2, j]] += bp_m
+            hamdat[i, indmap_2R[2, i, 1, j], indmap_1R[1, j]] += bm_p
+            hamdat[i, indmap_2R[2, i, 2, j], indmap_1R[2, j]] += bm_m
+            for k in (half_basis_size + 1):(i - 1)
+                hamdat[k, indmap_2R[1, i, 1, j], indmap_2R[1, i, 1, j]] = Elt(1)
+                hamdat[k, indmap_2R[1, i, 2, j], indmap_2R[1, i, 2, j]] = Elt(1)
+                hamdat[k, indmap_2R[2, i, 2, j], indmap_2R[2, i, 2, j]] = Elt(1)
+                hamdat[k, indmap_2R[2, i, 1, j], indmap_2R[2, i, 1, j]] = Elt(1)
             end
         end
-
     end
-    
-    
+
     # fill in all T terms
     # 1 | 1
-    for i in 1:basis_size, j in i+1:basis_size
+    for i in 1:basis_size, j in (i + 1):basis_size
         # m | p .
-        hamdat[j,indmap_1L[2,i],end] += K[j,i]*bp_ut;
-        
+        hamdat[j, indmap_1L[2, i], end] += K[j, i] * bp_ut
+
         # p | . m
-        hamdat[j,indmap_1L[1,i],end] += K[i,j]*bm_ut;
+        hamdat[j, indmap_1L[1, i], end] += K[i, j] * bm_ut
     end
-    
-    
+
     # fill in all V terms
 
-    
     # 1|3
-    @plansor ppLm[-1 -2;-3 -4] := bp[-1;1 -2]*h_pm[1;-3]*conj(ut[-4])
-    @plansor Lpmm[-1 -2;-3 -4] := bm[-1;-3 1]*h_pm[-2;1]*conj(ut[-4])
-    for i in 1:basis_size,j in i+1:basis_size
+    @plansor ppLm[-1 -2;-3 -4] := bp[-1;1 -2] * h_pm[1;-3] * conj(ut[-4])
+    @plansor Lpmm[-1 -2;-3 -4] := bm[-1;-3 1] * h_pm[-2;1] * conj(ut[-4])
+    for i in 1:basis_size,j in (i + 1):basis_size
         # m | p p . m
         # m | p p m .
-        hamdat[j,indmap_1L[2,i],end] += (V[j,j,i,j]+V[j,j,j,i])*ppLm;
+        hamdat[j, indmap_1L[2, i], end] += (V[j, j, i, j] + V[j, j, j, i]) * ppLm
 
         # p | . p m m
         # p | p . m m
-        hamdat[j,indmap_1L[1,i],end] += (V[j,i,j,j]+V[i,j,j,j])*Lpmm;
+        hamdat[j, indmap_1L[1, i], end] += (V[j, i, j, j] + V[i, j, j, j]) * Lpmm
     end
-    
+
     # 3|1
-    @plansor ppRm[-1 -2;-3 -4] := ut[-1]*ap[1 -2;-4]*h_pm[1;-3]
-    @plansor Rpmm[-1 -2;-3 -4] := ut[-1]*h_pm[-2;1]*am[-3 1;-4]
-    for i in 1:basis_size,j in i+1:basis_size
+    @plansor ppRm[-1 -2;-3 -4] := ut[-1] * ap[1 -2;-4] * h_pm[1;-3]
+    @plansor Rpmm[-1 -2;-3 -4] := ut[-1] * h_pm[-2;1] * am[-3 1;-4]
+    for i in 1:basis_size,j in (i + 1):basis_size
         # p p . m | m
         # p p m . | m
-        hamdat[i,1,indmap_1R[2,j]] += (V[i,i,j,i]+V[i,i,i,j])*ppRm
+        hamdat[i, 1, indmap_1R[2, j]] += (V[i, i, j, i] + V[i, i, i, j]) * ppRm
 
         # . p m m | p
         # p . m m | p
-        hamdat[i,1,indmap_1R[1,j]] += (V[j,i,i,i]+V[i,j,i,i])*Rpmm
+        hamdat[i, 1, indmap_1R[1, j]] += (V[j, i, i, i] + V[i, j, i, i]) * Rpmm
     end
 
 
     # 1|2|1
-    @plansor LRmm[-1 -2;-3 -4] := am[1 -2;-4]*bm[-1;-3 1]
-    @plansor RLmm[-1 -2;-3 -4] := bm[-1;1 -2]*am[-3 1;-4]
+    @plansor LRmm[-1 -2;-3 -4] := am[1 -2;-4] * bm[-1;-3 1]
+    @plansor RLmm[-1 -2;-3 -4] := bm[-1;1 -2] * am[-3 1;-4]
 
-    @plansor ppLR[-1 -2;-3 -4] := ap[1 -2;-4]*bp[-1;-3 1]
-    @plansor ppRL[-1 -2;-3 -4] := bp[-1;1 -2]*ap[-3 1;-4]
+    @plansor ppLR[-1 -2;-3 -4] := ap[1 -2;-4] * bp[-1;-3 1]
+    @plansor ppRL[-1 -2;-3 -4] := bp[-1;1 -2] * ap[-3 1;-4]
 
-    @plansor LpRm[-1 -2;-3 -4] := ap[1 -2;-4]*bm[-1;-3 1]
-    @plansor pLmR[-1 -2;-3 -4] := ap[1 -2;-4]*bm[-1;-3 1]
-    
-    @plansor RpLm[-1 -2;-3 -4] := bp[-1;1 -2]*am[-3 1;-4]
-    @plansor pRmL[-1 -2;-3 -4] := bp[-1;1 -2]*am[-3 1;-4]
+    @plansor LpRm[-1 -2;-3 -4] := ap[1 -2;-4] * bm[-1;-3 1]
+    @plansor pLmR[-1 -2;-3 -4] := ap[1 -2;-4] * bm[-1;-3 1]
 
-    @plansor LpmR[-1 -2;-3 -4] := h_pm[4;-3]*iso_pp[-1;3]*τ[3 -2;4 -4]
-    @plansor pLRm[-1 -2;-3 -4] := iso_pp[-1;1]*τ[1 -2;2 -4]*h_pm[2;-3]
+    @plansor RpLm[-1 -2;-3 -4] := bp[-1;1 -2] * am[-3 1;-4]
+    @plansor pRmL[-1 -2;-3 -4] := bp[-1;1 -2] * am[-3 1;-4]
 
-    @plansor RpmL[-1 -2;-3 -4] := h_pm[4;-3]*iso_mm[-1;3]*τ[3 -2;4 -4]
-    @plansor pRLm[-1 -2;-3 -4] := iso_mm[-1;1]*τ[1 -2;2 -4]*h_pm[2;-3]
-    
-    for i in 1:basis_size,j in i+1:basis_size,k in j+1:basis_size
+    @plansor LpmR[-1 -2;-3 -4] := h_pm[4;-3] * iso_pp[-1;3] * τ[3 -2;4 -4]
+    @plansor pLRm[-1 -2;-3 -4] := iso_pp[-1;1] * τ[1 -2;2 -4] * h_pm[2;-3]
+
+    @plansor RpmL[-1 -2;-3 -4] := h_pm[4;-3] * iso_mm[-1;3] * τ[3 -2;4 -4]
+    @plansor pRLm[-1 -2;-3 -4] := iso_mm[-1;1] * τ[1 -2;2 -4] * h_pm[2;-3]
+
+    for i in 1:basis_size,j in (i + 1):basis_size,k in (j + 1):basis_size
         # L R m m
-        hamdat[j,indmap_1L[1,i],indmap_1R[1,k]] += V[i,k,j,j]*LRmm
+        hamdat[j, indmap_1L[1, i], indmap_1R[1, k]] += V[i, k, j, j] * LRmm
 
         # R L m m
-        hamdat[j,indmap_1L[1,i],indmap_1R[1,k]] += V[k,i,j,j]*RLmm;
-        
+        hamdat[j, indmap_1L[1, i], indmap_1R[1, k]] += V[k, i, j, j] * RLmm
+
         # p p L R
-        hamdat[j,indmap_1L[2,i],indmap_1R[2,k]] += V[j,j,i,k]*ppLR
+        hamdat[j, indmap_1L[2, i], indmap_1R[2, k]] += V[j, j, i, k] * ppLR
 
         # p p R L
-        hamdat[j,indmap_1L[2,i],indmap_1R[2,k]] += V[j,j,k,i]*ppRL
+        hamdat[j, indmap_1L[2, i], indmap_1R[2, k]] += V[j, j, k, i] * ppRL
 
         # L p R m
         # p L m R
-        hamdat[j,indmap_1L[1,i],indmap_1R[2,k]] += (V[j,i,j,k]+V[i,j,k,j])*LpRm
+        hamdat[j, indmap_1L[1, i], indmap_1R[2, k]] += (V[j, i, j, k] + V[i, j, k, j]) * LpRm
 
         # R p L m
         # p R m L
-        hamdat[j,indmap_1L[2,i],indmap_1R[1,k]] += (V[j,k,j,i]+V[k,j,i,j])*RpLm
+        hamdat[j, indmap_1L[2, i], indmap_1R[1, k]] += (V[j, k, j, i] + V[k, j, i, j]) * RpLm
 
         # L p m R
-        hamdat[j,indmap_1L[1,i],indmap_1R[2,k]] += V[i,j,j,k]*LpmR
+        hamdat[j, indmap_1L[1, i], indmap_1R[2, k]] += V[i, j, j, k] * LpmR
 
         # p L R m
-        hamdat[j,indmap_1L[1,i],indmap_1R[2,k]] += V[j,i,k,j]*pLRm
+        hamdat[j, indmap_1L[1, i], indmap_1R[2, k]] += V[j, i, k, j] * pLRm
 
         # R p m L
-        hamdat[j,indmap_1L[2,i],indmap_1R[1,k]] += V[k,j,j,i]*RpmL
+        hamdat[j, indmap_1L[2, i], indmap_1R[1, k]] += V[k, j, j, i] * RpmL
 
         # p R L m
-        hamdat[j,indmap_1L[2,i],indmap_1R[1,k]] += V[j,k,i,j]*pRLm
+        hamdat[j, indmap_1L[2, i], indmap_1R[1, k]] += V[j, k, i, j] * pRLm
     end
-    
-    
+
+
     # 2|2
-    @plansor __mm[-1 -2;-3 -4] := pp_f[-1;1 2]*bm[1;-3 3]*bm[2;3 -2]*conj(ut[-4])
-    @plansor __pp[-1 -2;-3 -4] := mm_f[-1;1 2]*bp[1;-3 3]*bp[2;3 -2]*conj(ut[-4])
-    @plansor _p_m[-1 -2;-3 -4] := mp_f[-1;1 2] * bp[1;-3 3]*bm[2;3 -2]*conj(ut[-4])
-    @plansor _pm_[-1 -2;-3 -4] := mp_f[-1;1 2]*Lmap_apam_to_pm[1 2]*h_pm[-2;-3]*conj(ut[-4])
-    p_m_ = _p_m;
-    p__m = _pm_;
-    
-    for i in 1:half_basis_size, j in i+1:half_basis_size
+    @plansor __mm[-1 -2;-3 -4] := pp_f[-1;1 2] * bm[1;-3 3] * bm[2;3 -2] * conj(ut[-4])
+    @plansor __pp[-1 -2;-3 -4] := mm_f[-1;1 2] * bp[1;-3 3] * bp[2;3 -2] * conj(ut[-4])
+    @plansor _p_m[-1 -2;-3 -4] := mp_f[-1;1 2] * bp[1;-3 3] * bm[2;3 -2] * conj(ut[-4])
+    @plansor _pm_[-1 -2;-3 -4] := mp_f[-1;1 2] * Lmap_apam_to_pm[1 2] * h_pm[-2;-3] * conj(ut[-4])
+    p_m_ = _p_m
+    p__m = _pm_
+
+    for i in 1:half_basis_size, j in (i + 1):half_basis_size
         # p p | . . m m
-        hamdat[j,indmap_2L[1,i,1,i],end] += V[i,i,j,j]*__mm;
+        hamdat[j, indmap_2L[1, i, 1, i], end] += V[i, i, j, j] * __mm
 
         # m m | p p . .
-        hamdat[j,indmap_2L[2,i,2,i],end] += V[j,j,i,i]*__pp;
+        hamdat[j, indmap_2L[2, i, 2, i], end] += V[j, j, i, i] * __pp
 
         # p m | . p . m
-        hamdat[j,indmap_2L[2,i,1,i],end] += V[i,j,i,j]*_p_m;
-        hamdat[i,1,end] -= V[i,j,i,j]*add_util_leg(h_pm);
+        hamdat[j, indmap_2L[2, i, 1, i], end] += V[i, j, i, j] * _p_m
+        hamdat[i, 1, end] -= V[i, j, i, j] * add_util_leg(h_pm)
 
         # p m | p . m .
-        hamdat[j,indmap_2L[2,i,1,i],end] += V[j,i,j,i]*p_m_;
-        hamdat[i,1,end] -= V[j,i,j,i]*add_util_leg(h_pm);
-        
+        hamdat[j, indmap_2L[2, i, 1, i], end] += V[j, i, j, i] * p_m_
+        hamdat[i, 1, end] -= V[j, i, j, i] * add_util_leg(h_pm)
+
         # p m | . p m .
-        hamdat[j,indmap_2L[2,i,1,i],end] += V[i,j,j,i]*_pm_;
+        hamdat[j, indmap_2L[2, i, 1, i], end] += V[i, j, j, i] * _pm_
 
         # p m | p . . m
-        hamdat[j,indmap_2L[2,i,1,i],end] += V[j,i,i,j]*_pm_;
+        hamdat[j, indmap_2L[2, i, 1, i], end] += V[j, i, i, j] * _pm_
     end
-    
-    @plansor __mm[-1 -2;-3 -4] := ut[-1]*am[-3 1;2]*am[1 -2;3]*conj(mm_f[-4;2 3])
-    @plansor __pp[-1 -2;-3 -4] := ut[-1]*ap[-3 1;2]*ap[1 -2;3]*conj(pp_f[-4;2 3])
-    @plansor _p_m[-1 -2;-3 -4] := ut[-1]*ap[-3 1;2]*am[1 -2;3]*conj(pm_f[-4;2 3])
-    p_m_ = _p_m;
-    @plansor _pm_[-1 -2;-3 -4] := ut[-1]*h_pm[-2;-3]*(transpose(Rmap_bpbm_to_pm*pm_f',(1,)))[-4]
-    p__m = _pm_
-    
-    for i in half_basis_size:basis_size, j in i+1:basis_size
-        #  . . m m | p p
-        hamdat[i,1,indmap_2R[1,j,1,j]] += V[j,j,i,i]*__mm;
 
-        # p p . . | m m 
-        hamdat[i,1,indmap_2R[2,j,2,j]] += V[i,i,j,j]*__pp;
+    @plansor __mm[-1 -2;-3 -4] := ut[-1] * am[-3 1;2] * am[1 -2;3] * conj(mm_f[-4;2 3])
+    @plansor __pp[-1 -2;-3 -4] := ut[-1] * ap[-3 1;2] * ap[1 -2;3] * conj(pp_f[-4;2 3])
+    @plansor _p_m[-1 -2;-3 -4] := ut[-1] * ap[-3 1;2] * am[1 -2;3] * conj(pm_f[-4;2 3])
+    p_m_ = _p_m
+    @plansor _pm_[-1 -2;-3 -4] := ut[-1] * h_pm[-2;-3] * (transpose(Rmap_bpbm_to_pm * pm_f', ((1,), ())))[-4]
+    p__m = _pm_
+
+    for i in half_basis_size:basis_size, j in (i + 1):basis_size
+        #  . . m m | p p
+        hamdat[i, 1, indmap_2R[1, j, 1, j]] += V[j, j, i, i] * __mm
+
+        # p p . . | m m
+        hamdat[i, 1, indmap_2R[2, j, 2, j]] += V[i, i, j, j] * __pp
 
         # . p . m | p m
-        hamdat[i,1,indmap_2R[2,j,1,j]] += V[j,i,j,i]*_p_m;
-        hamdat[j,1,end] -= V[j,i,j,i]*add_util_leg(h_pm);
+        hamdat[i, 1, indmap_2R[2, j, 1, j]] += V[j, i, j, i] * _p_m
+        hamdat[j, 1, end] -= V[j, i, j, i] * add_util_leg(h_pm)
 
         #  p . m . | p m
-        hamdat[i,1,indmap_2R[2,j,1,j]] += V[i,j,i,j]*_p_m;
-        hamdat[j,1,end] -= V[i,j,i,j]*add_util_leg(h_pm);
-        
+        hamdat[i, 1, indmap_2R[2, j, 1, j]] += V[i, j, i, j] * _p_m
+        hamdat[j, 1, end] -= V[i, j, i, j] * add_util_leg(h_pm)
+
         #  . p m . | p m
-        hamdat[i,1,indmap_2R[2,j,1,j]] += V[i,j,j,i]*_pm_;
+        hamdat[i, 1, indmap_2R[2, j, 1, j]] += V[i, j, j, i] * _pm_
 
         #  p . . m | p m
-        hamdat[i,1,indmap_2R[2,j,1,j]] += V[j,i,i,j]*_pm_;
+        hamdat[i, 1, indmap_2R[2, j, 1, j]] += V[j, i, i, j] * _pm_
     end
-    
-    
-    for i in 1:half_basis_size-1, j in half_basis_size+1:basis_size
+
+
+    for i in 1:(half_basis_size - 1), j in (half_basis_size + 1):basis_size
         # m m | p p
-        mmpp = permute(isometry(storagetype(ap),_firstspace(mm_f)*psp,_firstspace(mm_f)*psp),(1,2),(4,3));
-        hamdat[half_basis_size,indmap_2L[2,i,2,i],indmap_2R[1,j,1,j]] += mmpp*(V[j,j,i,i])
+        mmpp = permute(isometry(storagetype(ap), MPSKit._firstspace(mm_f) * psp, MPSKit._firstspace(mm_f) * psp), ((1, 2), (4, 3)))
+        hamdat[half_basis_size, indmap_2L[2, i, 2, i], indmap_2R[1, j, 1, j]] += mmpp * (V[j, j, i, i])
 
         # p p | m p
-        ppmm = permute(isometry(storagetype(ap),_firstspace(pp_f)*psp,_firstspace(pp_f)*psp),(1,2),(4,3));
-        hamdat[half_basis_size,indmap_2L[1,i,1,i],indmap_2R[2,j,2,j]] += ppmm*(V[i,i,j,j])
+        ppmm = permute(isometry(storagetype(ap), MPSKit._firstspace(pp_f) * psp, MPSKit._firstspace(pp_f) * psp), ((1, 2), (4, 3)))
+        hamdat[half_basis_size, indmap_2L[1, i, 1, i], indmap_2R[2, j, 2, j]] += ppmm * (V[i, i, j, j])
 
         # . p . m | p m
-        # p . m . | p m 
-        @plansor RLRL[-1 -2;-3 -4] := pm_f[-1;1 2]*ai[3;-3]*τ[3 1;4 5]*τ[5 2;6 -2]*conj(pm_f[-4;4 6])
-        hamdat[half_basis_size,indmap_2L[1,i,2,i],indmap_2R[2,j,1,j]] += (V[i,j,i,j]+V[j,i,j,i])*RLRL;
-        hamdat[j,1,end] -= add_util_leg(h_pm)*(V[i,j,i,j]+V[j,i,j,i])
-        
+        # p . m . | p m
+        @plansor RLRL[-1 -2;-3 -4] := pm_f[-1;1 2] * ai[3;-3] * τ[3 1;4 5] * τ[5 2;6 -2] * conj(pm_f[-4;4 6])
+        hamdat[half_basis_size, indmap_2L[1, i, 2, i], indmap_2R[2, j, 1, j]] += (V[i, j, i, j] + V[j, i, j, i]) * RLRL
+        hamdat[j, 1, end] -= add_util_leg(h_pm) * (V[i, j, i, j] + V[j, i, j, i])
+
         # . p m .
         # p . . m
-        @plansor RLLR[-1 -2;-3 -4] := mp_f[-1;1 2]*Lmap_apam_to_pm[1 2]*ai[-2;-3]*(transpose(Rmap_bpbm_to_pm*pm_f',(1,)))[-4]
-        hamdat[half_basis_size,indmap_2L[2,i,1,i],indmap_2R[2,j,1,j]] += (V[i,j,j,i]+V[j,i,i,j])*RLLR;
+        @plansor RLLR[-1 -2;-3 -4] := mp_f[-1;1 2] * Lmap_apam_to_pm[1 2] * ai[-2;-3] * (transpose(Rmap_bpbm_to_pm * pm_f', ((1,), ())))[-4]
+        hamdat[half_basis_size, indmap_2L[2, i, 1, i], indmap_2R[2, j, 1, j]] += (V[i, j, j, i] + V[j, i, i, j]) * RLLR
     end
-    
-    
+
+
     # 2|1|1
-    @plansor __mm[-1 -2;-3 -4]:= am[-3 1;2]*am[1 -2;3]*conj(mm_f[-4;2 3])*ut[-1]
-    @plansor pp__[-1 -2;-3 -4] := ap[-3 1;2]*ap[1 -2;3]*conj(pp_f[-4;2 3])*ut[-1]
-    @plansor pjkm[-1 -2;-3 -4] := ut[-1]*h_pm[-2;-3]*Rmap_bp_to_ap[1;2]*conj(mp_f[-4;1 2])
-    @plansor pkjm[-1 -2;-3 -4] := ut[-1]*h_pm[-2;-3]*Rmap_bm_to_am[1;2]*conj(pm_f[-4;1 2])
-    @plansor jpkm[-1 -2;-3 -4] := am[-3 1;2]*ap[1 -2;3]*conj(mp_f[-4;2 3])*ut[-1]
-    @plansor kpjm[-1 -2;-3 -4] := ap[-3 1;2]*am[1 -2;3]*conj(pm_f[-4;2 3])*ut[-1]
-    @plansor kpjm[-1 -2;-3 -4] := am[-3 1;4]*ap[1 -2;5]*τ[4 5;2 3]*conj(pm_f[-4;2 3])*ut[-1]
+    @plansor __mm[-1 -2;-3 -4] := am[-3 1;2] * am[1 -2;3] * conj(mm_f[-4;2 3]) * ut[-1]
+    @plansor pp__[-1 -2;-3 -4] := ap[-3 1;2] * ap[1 -2;3] * conj(pp_f[-4;2 3]) * ut[-1]
+    @plansor pjkm[-1 -2;-3 -4] := ut[-1] * h_pm[-2;-3] * Rmap_bp_to_ap[1;2] * conj(mp_f[-4;1 2])
+    @plansor pkjm[-1 -2;-3 -4] := ut[-1] * h_pm[-2;-3] * Rmap_bm_to_am[1;2] * conj(pm_f[-4;1 2])
+    @plansor jpkm[-1 -2;-3 -4] := am[-3 1;2] * ap[1 -2;3] * conj(mp_f[-4;2 3]) * ut[-1]
+    @plansor kpjm[-1 -2;-3 -4] := ap[-3 1;2] * am[1 -2;3] * conj(pm_f[-4;2 3]) * ut[-1]
+    @plansor kpjm[-1 -2;-3 -4] := am[-3 1;4] * ap[1 -2;5] * τ[4 5;2 3] * conj(pm_f[-4;2 3]) * ut[-1]
 
-    @plansor LLmR[-1 -2;-3 -4] := pp_f[-1;1 2]*bm[1;-3 3]*τ[3 2;-4 -2]
-    @plansor RpLL[-1 -2;-3 -4] := mm_f[-1;1 2]*bp[2;3 -2]*τ[1 3;-3 -4]
-    @plansor pLRL[-1 -2;-3 -4] := mp_f[-1;1 2]*bp[1;-3 3]*τ[3 2;-4 -2]
-    @plansor LRLm[-1 -2;-3 -4] := mp_f[-1;1 2]*bm[2;3 -2]*τ[1 3;-3 -4]
-    @plansor LpRL[-1 -2;-3 -4] := mp_f[-1;1 2]*Lmap_apam_to_pm[1 2]*ap[-3 -2;-4]
-    @plansor LRmL[-1 -2;-3 -4] := mp_f[-1;1 2]*Lmap_apam_to_pm[1 2]*am[-3 -2;-4]
+    @plansor LLmR[-1 -2;-3 -4] := pp_f[-1;1 2] * bm[1;-3 3] * τ[3 2;-4 -2]
+    @plansor RpLL[-1 -2;-3 -4] := mm_f[-1;1 2] * bp[2;3 -2] * τ[1 3;-3 -4]
+    @plansor pLRL[-1 -2;-3 -4] := mp_f[-1;1 2] * bp[1;-3 3] * τ[3 2;-4 -2]
+    @plansor LRLm[-1 -2;-3 -4] := mp_f[-1;1 2] * bm[2;3 -2] * τ[1 3;-3 -4]
+    @plansor LpRL[-1 -2;-3 -4] := mp_f[-1;1 2] * Lmap_apam_to_pm[1 2] * ap[-3 -2;-4]
+    @plansor LRmL[-1 -2;-3 -4] := mp_f[-1;1 2] * Lmap_apam_to_pm[1 2] * am[-3 -2;-4]
 
-    for i in half_basis_size:basis_size,j in i+1:basis_size,k in j+1:basis_size
+    for i in half_basis_size:basis_size,j in (i + 1):basis_size,k in (j + 1):basis_size
         # j k m m
         # k j m m
-        hamdat[i,1,indmap_2R[1,j,1,k]] += (V[j,k,i,i]+V[k,j,i,i])*__mm;
-        
+        hamdat[i, 1, indmap_2R[1, j, 1, k]] += (V[j, k, i, i] + V[k, j, i, i]) * __mm
+
         # p p j k
         # p p k j
-        hamdat[i,1,indmap_2R[2,j,2,k]] += (V[i,i,j,k]+V[i,i,k,j])*pp__;
-        
+        hamdat[i, 1, indmap_2R[2, j, 2, k]] += (V[i, i, j, k] + V[i, i, k, j]) * pp__
+
         # p j k m
         # j p m k
-        hamdat[i,1,indmap_2R[1,j,2,k]] += (V[j,i,i,k]+V[i,j,k,i])*pjkm
-        
+        hamdat[i, 1, indmap_2R[1, j, 2, k]] += (V[j, i, i, k] + V[i, j, k, i]) * pjkm
+
         # p k j m
         # k p m j
-        hamdat[i,1,indmap_2R[2,j,1,k]] += (V[k,i,i,j]+V[i,k,j,i])*pkjm
+        hamdat[i, 1, indmap_2R[2, j, 1, k]] += (V[k, i, i, j] + V[i, k, j, i]) * pkjm
 
         # j p k m
         # p j m k
-        hamdat[i,1,indmap_2R[1,j,2,k]] += (V[i,j,i,k]+V[j,i,k,i])*jpkm;
+        hamdat[i, 1, indmap_2R[1, j, 2, k]] += (V[i, j, i, k] + V[j, i, k, i]) * jpkm
 
         # k p j m
         # p k m j
-        hamdat[i,1,indmap_2R[2,j,1,k]] += (V[i,k,i,j]+V[k,i,j,i])*kpjm        
+        hamdat[i, 1, indmap_2R[2, j, 1, k]] += (V[i, k, i, j] + V[k, i, j, i]) * kpjm
     end
-    
-    for i in 1:half_basis_size,j in i+1:half_basis_size,k in j+1:basis_size
-        # L L m R    
+
+    for i in 1:half_basis_size,j in (i + 1):half_basis_size,k in (j + 1):basis_size
+        # L L m R
         # L L R m
-        hamdat[j,indmap_2L[1,i,1,i],indmap_1R[2,k]] += (V[i,i,k,j]+V[i,i,j,k])*LLmR
+        hamdat[j, indmap_2L[1, i, 1, i], indmap_1R[2, k]] += (V[i, i, k, j] + V[i, i, j, k]) * LLmR
 
         # R p L L
         # p R L L
-        hamdat[j,indmap_2L[2,i,2,i],indmap_1R[1,k]] += (V[j,k,i,i]+V[k,j,i,i])*RpLL
+        hamdat[j, indmap_2L[2, i, 2, i], indmap_1R[1, k]] += (V[j, k, i, i] + V[k, j, i, i]) * RpLL
 
         # p L R L
         # L p L R
-        hamdat[j,indmap_2L[2,i,1,i],indmap_1R[2,k]] += (V[i,j,i,k]+V[j,i,k,i])*pLRL
-        
+        hamdat[j, indmap_2L[2, i, 1, i], indmap_1R[2, k]] += (V[i, j, i, k] + V[j, i, k, i]) * pLRL
+
         # L R L m
         # R L m L
-        hamdat[j,indmap_2L[2,i,1,i],indmap_1R[1,k]] += (V[k,i,j,i]+V[i,k,i,j])*LRLm
+        hamdat[j, indmap_2L[2, i, 1, i], indmap_1R[1, k]] += (V[k, i, j, i] + V[i, k, i, j]) * LRLm
 
         # L p R L
         # p L L R
-        hamdat[j,indmap_2L[2,i,1,i],indmap_1R[2,k]] += (V[j,i,i,k]+V[i,j,k,i])*LpRL
+        hamdat[j, indmap_2L[2, i, 1, i], indmap_1R[2, k]] += (V[j, i, i, k] + V[i, j, k, i]) * LpRL
 
         # L R m L
         # R L L m
-        hamdat[j,indmap_2L[2,i,1,i],indmap_1R[1,k]] += (V[k,i,i,j]+V[i,k,j,i])*LRmL 
+        hamdat[j, indmap_2L[2, i, 1, i], indmap_1R[1, k]] += (V[k, i, i, j] + V[i, k, j, i]) * LRmL
     end
-    
-    for i in 1:half_basis_size-1,j in half_basis_size+1:basis_size,k in j+1:basis_size
+
+    for i in 1:(half_basis_size - 1),j in (half_basis_size + 1):basis_size,k in (j + 1):basis_size
         # j k i i
         # k j i i
-        @plansor jkii[-1 -2;-3 -4] := mm_f[-1;1 2]*ai[3;-3]*τ[3 1;4 5]*τ[5 2;6 -2]*conj(mm_f[-4;4 6])
-        hamdat[half_basis_size,indmap_2L[2,i,2,i],indmap_2R[1,j,1,k]] += (V[j,k,i,i]+V[k,j,i,i])*jkii;
-        
+        @plansor jkii[-1 -2;-3 -4] := mm_f[-1;1 2] * ai[3;-3] * τ[3 1;4 5] * τ[5 2;6 -2] * conj(mm_f[-4;4 6])
+        hamdat[half_basis_size, indmap_2L[2, i, 2, i], indmap_2R[1, j, 1, k]] += (V[j, k, i, i] + V[k, j, i, i]) * jkii
+
         # i i j k
         # i i k j
-        @plansor iijk[-1 -2;-3 -4] := pp_f[-1;1 2]*ai[3;-3]*τ[3 1;4 5]*τ[5 2;6 -2]*conj(pp_f[-4;4 6])
-        hamdat[half_basis_size,indmap_2L[1,i,1,i],indmap_2R[2,j,2,k]] += (V[i,i,j,k]+V[i,i,k,j])*iijk;
-        
+        @plansor iijk[-1 -2;-3 -4] := pp_f[-1;1 2] * ai[3;-3] * τ[3 1;4 5] * τ[5 2;6 -2] * conj(pp_f[-4;4 6])
+        hamdat[half_basis_size, indmap_2L[1, i, 1, i], indmap_2R[2, j, 2, k]] += (V[i, i, j, k] + V[i, i, k, j]) * iijk
+
         # i j k i
         # j i i k
-        @plansor ijki[-1 -2;-3 -4] := mp_f[-1;1 2]*Lmap_apam_to_pm[1 2]*ai[-2;-3]*Rmap_bp_to_ap[3;4]*conj(mp_f[-4;3 4])
-        hamdat[half_basis_size,indmap_2L[2,i,1,i],indmap_2R[1,j,2,k]] += (V[j,i,i,k]+V[i,j,k,i])*ijki
-        
+        @plansor ijki[-1 -2;-3 -4] := mp_f[-1;1 2] * Lmap_apam_to_pm[1 2] * ai[-2;-3] * Rmap_bp_to_ap[3;4] * conj(mp_f[-4;3 4])
+        hamdat[half_basis_size, indmap_2L[2, i, 1, i], indmap_2R[1, j, 2, k]] += (V[j, i, i, k] + V[i, j, k, i]) * ijki
+
         # i k j i
         # k i i j
-        @plansor ikji[-1 -2;-3 -4] := mp_f[-1;1 2]*Lmap_apam_to_pm[1 2]*ai[-2;-3]*Rmap_bm_to_am[3;4]*conj(pm_f[-4;3 4])
-        hamdat[half_basis_size,indmap_2L[2,i,1,i],indmap_2R[2,j,1,k]] += (V[k,i,i,j]+V[i,k,j,i])*ikji
+        @plansor ikji[-1 -2;-3 -4] := mp_f[-1;1 2] * Lmap_apam_to_pm[1 2] * ai[-2;-3] * Rmap_bm_to_am[3;4] * conj(pm_f[-4;3 4])
+        hamdat[half_basis_size, indmap_2L[2, i, 1, i], indmap_2R[2, j, 1, k]] += (V[k, i, i, j] + V[i, k, j, i]) * ikji
 
         # j i k i
         # i j i k
-        @plansor jiki[-1 -2;-3 -4] := mp_f[-1;1 2]*ai[3;-3]*τ[3 1;4 5]*τ[5 2;6 -2]*conj(mp_f[-4;4 6])
-        hamdat[half_basis_size,indmap_2L[2,i,1,i],indmap_2R[1,j,2,k]] += (V[i,j,i,k]+V[j,i,k,i])*jiki;
+        @plansor jiki[-1 -2;-3 -4] := mp_f[-1;1 2] * ai[3;-3] * τ[3 1;4 5] * τ[5 2;6 -2] * conj(mp_f[-4;4 6])
+        hamdat[half_basis_size, indmap_2L[2, i, 1, i], indmap_2R[1, j, 2, k]] += (V[i, j, i, k] + V[j, i, k, i]) * jiki
 
         # k i j i
         # i k i j
-        @plansor kiji[-1 -2;-3 -4] := mp_f[-1;7 8]*τ[7 8;1 2] *ai[3;-3]*τ[3 1;4 5]*τ[5 2;6 -2]*conj(pm_f[-4;4 6])
-        hamdat[half_basis_size,indmap_2L[2,i,1,i],indmap_2R[2,j,1,k]] += (V[k,i,j,i]+V[i,k,i,j])*kiji;
-        
+        @plansor kiji[-1 -2;-3 -4] := mp_f[-1;7 8] * τ[7 8;1 2] * ai[3;-3] * τ[3 1;4 5] * τ[5 2;6 -2] * conj(pm_f[-4;4 6])
+        hamdat[half_basis_size, indmap_2L[2, i, 1, i], indmap_2R[2, j, 1, k]] += (V[k, i, j, i] + V[i, k, i, j]) * kiji
+
     end
-    
-    
+
+
     # 1|1|2
     # (i,j) in indmap_2, 2 onsite
-    @plansor jimm[-1 -2;-3 -4] := bm[1;-3 2]*bm[3;2 -2]*τ[4 5;1 3]*pp_f[-1;4 5]*conj(ut[-4])
-    @plansor ijmm[-1 -2;-3 -4] := bm[1;-3 2]*bm[3;2 -2]*τ[4 5;1 3]*permute(pp_f,(1,),(3,2))[-1;4 5]*conj(ut[-4])
-    @plansor jpim[-1 -2;-3 -4] := bm[1;-3 2]*bp[3;2 -2]*τ[4 5;1 3]*mp_f[-1;4 5]*conj(ut[-4])
-    @plansor ipjm[-1 -2;-3 -4] := bm[1;-3 2]*bp[3;2 -2]*τ[4 5;1 3]*permute(pm_f,(1,),(3,2))[-1;4 5]*conj(ut[-4])
-    @plansor ppji[-1 -2;-3 -4] := mm_f[-1;1 2]*bp[1;-3 3]*bp[2;3 -2]*conj(ut[-4])
-    @plansor ppij[-1 -2;-3 -4] := permute(mm_f,(1,),(3,2))[-1;1 2]*bp[1;-3 3]*bp[2;3 -2]*conj(ut[-4])
-    @plansor jpmi[-1 -2;-3 -4] := ut[-1]*h_pm[-2;-3]*conj(ut[-4])
-    @plansor ipmj[-1 -2;-3 -4] := ut[-1]*h_pm[-2;-3]*conj(ut[-4])
+    @plansor jimm[-1 -2;-3 -4] := bm[1;-3 2] * bm[3;2 -2] * τ[4 5;1 3] * pp_f[-1;4 5] * conj(ut[-4])
+    @plansor ijmm[-1 -2;-3 -4] := bm[1;-3 2] * bm[3;2 -2] * τ[4 5;1 3] * permute(pp_f, ((1,), (3, 2)))[-1;4 5] * conj(ut[-4])
+    @plansor jpim[-1 -2;-3 -4] := bm[1;-3 2] * bp[3;2 -2] * τ[4 5;1 3] * mp_f[-1;4 5] * conj(ut[-4])
+    @plansor ipjm[-1 -2;-3 -4] := bm[1;-3 2] * bp[3;2 -2] * τ[4 5;1 3] * permute(pm_f, ((1,), (3, 2)))[-1;4 5] * conj(ut[-4])
+    @plansor ppji[-1 -2;-3 -4] := mm_f[-1;1 2] * bp[1;-3 3] * bp[2;3 -2] * conj(ut[-4])
+    @plansor ppij[-1 -2;-3 -4] := permute(mm_f, ((1,), (3, 2)))[-1;1 2] * bp[1;-3 3] * bp[2;3 -2] * conj(ut[-4])
+    @plansor jpmi[-1 -2;-3 -4] := ut[-1] * h_pm[-2;-3] * conj(ut[-4])
+    @plansor ipmj[-1 -2;-3 -4] := ut[-1] * h_pm[-2;-3] * conj(ut[-4])
 
-    pjmi = jpim;
-    pimj = ipjm;
-    
-    @plansor connect_am_ap[-1 -2;-3 -4] := mp_f[-1;1 2]*Lmap_ap_to_bp[2;1]*h_pm[-2;-3]*conj(ut[-4])
-    @plansor connect_ap_am[-1 -2;-3 -4] := pm_f[-1;1 2]*Lmap_am_to_bm[2;1]*h_pm[-2;-3]*conj(ut[-4])
+    pjmi = jpim
+    pimj = ipjm
 
-    for i in 1:basis_size,j in i+1:basis_size,k in j+1:basis_size
-        k <=half_basis_size || continue
+    @plansor connect_am_ap[-1 -2;-3 -4] := mp_f[-1;1 2] * Lmap_ap_to_bp[2;1] * h_pm[-2;-3] * conj(ut[-4])
+    @plansor connect_ap_am[-1 -2;-3 -4] := pm_f[-1;1 2] * Lmap_am_to_bm[2;1] * h_pm[-2;-3] * conj(ut[-4])
+
+    for i in 1:basis_size,j in (i + 1):basis_size,k in (j + 1):basis_size
+        k <= half_basis_size || continue
 
         # j i m m
-        hamdat[k,indmap_2L[1,i,1,j],end] += V[j,i,k,k]*jimm
+        hamdat[k, indmap_2L[1, i, 1, j], end] += V[j, i, k, k] * jimm
         # i j m m
-        hamdat[k,indmap_2L[1,i,1,j],end] += V[i,j,k,k]*ijmm;
+        hamdat[k, indmap_2L[1, i, 1, j], end] += V[i, j, k, k] * ijmm
 
         # j p i m
-        hamdat[k,indmap_2L[2,i,1,j],end] += V[j,k,i,k]*jpim
-        hamdat[k,indmap_2L[2,i,1,j],end] += V[k,j,k,i]*pjmi
+        hamdat[k, indmap_2L[2, i, 1, j], end] += V[j, k, i, k] * jpim
+        hamdat[k, indmap_2L[2, i, 1, j], end] += V[k, j, k, i] * pjmi
 
         # i p j m
-        hamdat[k,indmap_2L[1,i,2,j],end] += V[i,k,j,k]*ipjm
-        hamdat[k,indmap_2L[1,i,2,j],end] += V[k,i,k,j]*pimj
+        hamdat[k, indmap_2L[1, i, 2, j], end] += V[i, k, j, k] * ipjm
+        hamdat[k, indmap_2L[1, i, 2, j], end] += V[k, i, k, j] * pimj
 
         # j p m i
-        hamdat[k,indmap_2L[2,i,1,j],end] += (V[j,k,k,i]+V[k,j,i,k])*connect_am_ap
+        hamdat[k, indmap_2L[2, i, 1, j], end] += (V[j, k, k, i] + V[k, j, i, k]) * connect_am_ap
 
         # i p m j
-        hamdat[k,indmap_2L[1,i,2,j],end] += (V[k,i,j,k]+V[i,k,k,j])*connect_ap_am
+        hamdat[k, indmap_2L[1, i, 2, j], end] += (V[k, i, j, k] + V[i, k, k, j]) * connect_ap_am
 
         # p p j i
-        hamdat[k,indmap_2L[2,i,2,j],end] += V[k,k,j,i]*ppji
+        hamdat[k, indmap_2L[2, i, 2, j], end] += V[k, k, j, i] * ppji
         # p p i j
-        hamdat[k,indmap_2L[2,i,2,j],end] += V[k,k,i,j]*ppij
+        hamdat[k, indmap_2L[2, i, 2, j], end] += V[k, k, i, j] * ppij
     end
 
-    @plansor jimm[-1 -2;-3 -4] := iso_pp[-1;1]*ap[-3 2;3]*τ[2 1;4 -2]*conj(pp_f[-4;3 4])
-    @plansor ppji[-1 -2;-3 -4] := iso_mm[-1;1]*am[-3 2;3]*τ[2 1;4 -2]*conj(mm_f[-4;3 4])
-    @plansor jpim[-1 -2;-3 -4] := iso_mm[-1;1]*ap[-3 2;3]*τ[2 1;4 -2]*conj(pm_f[-4;3 4])
-    @plansor ipjm[-1 -2;-3 -4] := iso_pp[-1;1]*τ[-3 1;2 3]*am[3 -2;4]*conj(pm_f[-4;2 4])
-    
-    @plansor jpmi[-1 -2;-3 -4] := bp[-1;-3 -2]*(transpose(Rmap_bpbm_to_pm*pm_f',(1,)))[-4]
-    @plansor ipmj[-1 -2;-3 -4] := bm[-1;-3 -2]*(transpose(Rmap_bpbm_to_pm*pm_f',(1,)))[-4]
-    for i in 1:basis_size,j in i+1:basis_size,k in j+1:basis_size
+    @plansor jimm[-1 -2;-3 -4] := iso_pp[-1;1] * ap[-3 2;3] * τ[2 1;4 -2] * conj(pp_f[-4;3 4])
+    @plansor ppji[-1 -2;-3 -4] := iso_mm[-1;1] * am[-3 2;3] * τ[2 1;4 -2] * conj(mm_f[-4;3 4])
+    @plansor jpim[-1 -2;-3 -4] := iso_mm[-1;1] * ap[-3 2;3] * τ[2 1;4 -2] * conj(pm_f[-4;3 4])
+    @plansor ipjm[-1 -2;-3 -4] := iso_pp[-1;1] * τ[-3 1;2 3] * am[3 -2;4] * conj(pm_f[-4;2 4])
+
+    @plansor jpmi[-1 -2;-3 -4] := bp[-1;-3 -2] * (transpose(Rmap_bpbm_to_pm * pm_f', ((1,), ())))[-4]
+    @plansor ipmj[-1 -2;-3 -4] := bm[-1;-3 -2] * (transpose(Rmap_bpbm_to_pm * pm_f', ((1,), ())))[-4]
+    for i in 1:basis_size,j in (i + 1):basis_size,k in (j + 1):basis_size
         j >= half_basis_size || continue
 
         # j i m m
         # i j m m
-        hamdat[j,indmap_1L[1,i],indmap_2R[2,k,2,k]] += (V[j,i,k,k]+V[i,j,k,k])*jimm
+        hamdat[j, indmap_1L[1, i], indmap_2R[2, k, 2, k]] += (V[j, i, k, k] + V[i, j, k, k]) * jimm
 
         # p p j i
         # p p i j
-        hamdat[j,indmap_1L[2,i],indmap_2R[1,k,1,k]] += (V[k,k,j,i]+V[k,k,i,j])*ppji
-        
+        hamdat[j, indmap_1L[2, i], indmap_2R[1, k, 1, k]] += (V[k, k, j, i] + V[k, k, i, j]) * ppji
+
         # j p i m
         # p j m i
-        hamdat[j,indmap_1L[2,i],indmap_2R[2,k,1,k]] += (V[j,k,i,k]+V[k,j,k,i])*jpim
+        hamdat[j, indmap_1L[2, i], indmap_2R[2, k, 1, k]] += (V[j, k, i, k] + V[k, j, k, i]) * jpim
 
         # i p j m
         # p i m j
-        hamdat[j,indmap_1L[1,i],indmap_2R[2,k,1,k]] += (V[i,k,j,k]+V[k,i,k,j])*ipjm
+        hamdat[j, indmap_1L[1, i], indmap_2R[2, k, 1, k]] += (V[i, k, j, k] + V[k, i, k, j]) * ipjm
 
         # j p m i
         # p j i m
-        hamdat[j,indmap_1L[2,i],indmap_2R[2,k,1,k]] += (V[k,j,i,k]+V[j,k,k,i])*jpmi
+        hamdat[j, indmap_1L[2, i], indmap_2R[2, k, 1, k]] += (V[k, j, i, k] + V[j, k, k, i]) * jpmi
 
         # i p m j
         # p i j m
-        hamdat[j,indmap_1L[1,i],indmap_2R[2,k,1,k]] += (V[i,k,k,j]+V[k,i,j,k])*ipmj
+        hamdat[j, indmap_1L[1, i], indmap_2R[2, k, 1, k]] += (V[i, k, k, j] + V[k, i, j, k]) * ipmj
     end
-    
-    @plansor jikk[-1 -2;-3 -4] := pp_f[-1;1 2]*ai[3;-3]*τ[3 1;4 5]*τ[5 2;6 -2]*conj(pp_f[-4;4 6])
-    @plansor kkji[-1 -2;-3 -4] := mm_f[-1;1 2]*ai[3;-3]*τ[3 1;4 5]*τ[5 2;6 -2]*conj(mm_f[-4;4 6])
-    @plansor jkki[-1 -2;-3 -4] := mp_f[-1;1 2]*Lmap_ap_to_bp[2;1]*ai[-2;-3]*(transpose(Rmap_bpbm_to_pm*pm_f',(1,)))[-4]
-    @plansor ikkj[-1 -2;-3 -4] := pm_f[-1;1 2]*Lmap_am_to_bm[2;1]*ai[-2;-3]*(transpose(Rmap_bpbm_to_pm*pm_f',(1,)))[-4]
-    @plansor jkik[-1 -2;-3 -4] := mp_f[-1;1 2]*ai[3;-3]*τ[3 1;4 5]*τ[5 2;6 -2]*τ[4 6;7 8]*conj(pm_f[-4;7 8])
-    @plansor ikjk[-1 -2;-3 -4] := pm_f[-1;1 2]*ai[3;-3]*τ[3 1;4 5]*τ[5 2;6 -2]*conj(pm_f[-4;4 6])
-    for i in 1:half_basis_size-1,j in i+1:half_basis_size-1, k in half_basis_size+1:basis_size
+
+    @plansor jikk[-1 -2;-3 -4] := pp_f[-1;1 2] * ai[3;-3] * τ[3 1;4 5] * τ[5 2;6 -2] * conj(pp_f[-4;4 6])
+    @plansor kkji[-1 -2;-3 -4] := mm_f[-1;1 2] * ai[3;-3] * τ[3 1;4 5] * τ[5 2;6 -2] * conj(mm_f[-4;4 6])
+    @plansor jkki[-1 -2;-3 -4] := mp_f[-1;1 2] * Lmap_ap_to_bp[2;1] * ai[-2;-3] * (transpose(Rmap_bpbm_to_pm * pm_f', ((1,), ())))[-4]
+    @plansor ikkj[-1 -2;-3 -4] := pm_f[-1;1 2] * Lmap_am_to_bm[2;1] * ai[-2;-3] * (transpose(Rmap_bpbm_to_pm * pm_f', ((1,), ())))[-4]
+    @plansor jkik[-1 -2;-3 -4] := mp_f[-1;1 2] * ai[3;-3] * τ[3 1;4 5] * τ[5 2;6 -2] * τ[4 6;7 8] * conj(pm_f[-4;7 8])
+    @plansor ikjk[-1 -2;-3 -4] := pm_f[-1;1 2] * ai[3;-3] * τ[3 1;4 5] * τ[5 2;6 -2] * conj(pm_f[-4;4 6])
+    for i in 1:(half_basis_size - 1),j in (i + 1):(half_basis_size - 1), k in (half_basis_size + 1):basis_size
         # j i k k
         # i j k k
-        hamdat[half_basis_size,indmap_2L[1,i,1,j],indmap_2R[2,k,2,k]] += (V[j,i,k,k]+V[i,j,k,k])*jikk
+        hamdat[half_basis_size, indmap_2L[1, i, 1, j], indmap_2R[2, k, 2, k]] += (V[j, i, k, k] + V[i, j, k, k]) * jikk
 
         # k k j i
         # k k i j
-        hamdat[half_basis_size,indmap_2L[2,i,2,j],indmap_2R[1,k,1,k]] += (V[k,k,j,i]+V[k,k,i,j])*kkji
-        
+        hamdat[half_basis_size, indmap_2L[2, i, 2, j], indmap_2R[1, k, 1, k]] += (V[k, k, j, i] + V[k, k, i, j]) * kkji
+
         # j k k i
         # k j i k
-        hamdat[half_basis_size,indmap_2L[2,i,1,j],indmap_2R[2,k,1,k]] += (V[k,j,i,k]+V[j,k,k,i])*jkki
+        hamdat[half_basis_size, indmap_2L[2, i, 1, j], indmap_2R[2, k, 1, k]] += (V[k, j, i, k] + V[j, k, k, i]) * jkki
 
         # i k k j
         # k i j k
-        hamdat[half_basis_size,indmap_2L[1,i,2,j],indmap_2R[2,k,1,k]] += (V[i,k,k,j]+V[k,i,j,k])*ikkj
+        hamdat[half_basis_size, indmap_2L[1, i, 2, j], indmap_2R[2, k, 1, k]] += (V[i, k, k, j] + V[k, i, j, k]) * ikkj
 
         # j k i k
         # k j k i
-        hamdat[half_basis_size,indmap_2L[2,i,1,j],indmap_2R[2,k,1,k]] += (V[j,k,i,k]+V[k,j,k,i])*jkik
-        
+        hamdat[half_basis_size, indmap_2L[2, i, 1, j], indmap_2R[2, k, 1, k]] += (V[j, k, i, k] + V[k, j, k, i]) * jkik
+
         # i k j k
         # k i k j
-        hamdat[half_basis_size,indmap_2L[1,i,2,j],indmap_2R[2,k,1,k]] += (V[i,k,j,k]+V[k,i,k,j])*ikjk
+        hamdat[half_basis_size, indmap_2L[1, i, 2, j], indmap_2R[2, k, 1, k]] += (V[i, k, j, k] + V[k, i, k, j]) * ikjk
     end
-    
-    
+
+
     # 1|1|1|1
     # (i,j) in indmap_2, 1 in indmap_4, 1 onsite
-    @plansor pjiR[-1 -2;-3 -4] := mp_f[-1;1 2]*Lmap_ap_to_bp[2;1]*ap[-3 -2;-4]
-    @plansor pijR[-1 -2;-3 -4] := pm_f[-1;1 2]*Lmap_am_to_bm[2;1]*ap[-3 -2;-4]
-    @plansor Rjim[-1 -2;-3 -4] := mp_f[-1;1 2]*Lmap_ap_to_bp[2;1]*am[-3 -2;-4]
-    @plansor Rijm[-1 -2;-3 -4] := pm_f[-1;1 2]*Lmap_am_to_bm[2;1]*am[-3 -2;-4]
-    @plansor jimR[-1 -2;-3 -4] := pp_f[-1;1 2]*τ[3 2;-4 -2]*bm[1;-3 3]
-    @plansor ijRm[-1 -2;-3 -4] := permute(pp_f,(1,),(3,2))[-1;1 2]*τ[1 3;-3 -4]*bm[2;3 -2]
-    @plansor ijmR[-1 -2;-3 -4] := permute(pp_f,(1,),(3,2))[-1;1 2]*τ[3 2;-4 -2]*bm[1;-3 3]
-    @plansor jiRm[-1 -2;-3 -4] := pp_f[-1;1 2]*τ[1 3;-3 -4]*bm[2;3 -2]
-    @plansor jpiR[-1 -2;-3 -4] := mp_f[-1;1 2]*τ[3 2;-4 -2]*bp[1;-3 3]
-    @plansor ipjR[-1 -2;-3 -4] := permute(pm_f,(1,),(3,2))[-1;1 2]*τ[3 2;-4 -2]*bp[1;-3 3]
-    @plansor jRim[-1 -2;-3 -4] := mp_f[-1;1 2]*τ[1 3;-3 -4]*bm[2;3 -2]
-    @plansor iRjm[-1 -2;-3 -4] := permute(pm_f,(1,),(3,2))[-1;1 2]*τ[1 3;-3 -4]*bm[2;3 -2]
-    @plansor Rpji[-1 -2;-3 -4] := mm_f[-1;1 2]*τ[1 3;-3 -4]*bp[2;3 -2]
-    @plansor pRij[-1 -2;-3 -4] := permute(mm_f,(1,),(3,2))[-1;1 2]*τ[3 2;-4 -2]*bp[1;-3 3]
-    @plansor Rpij[-1 -2;-3 -4] := permute(mm_f,(1,),(3,2))[-1;1 2]*τ[1 3;-3 -4]*bp[2;3 -2]
-    @plansor pRji[-1 -2;-3 -4] := mm_f[-1;1 2]*τ[3 2;-4 -2]*bp[1;-3 3]
-    @plansor kjil[-1 -2;-3 -4] := bp[-1;-3 -2]*Rmap_bp_to_ap[1;2]*conj(mp_f[-4;1 2])
-    @plansor ljik[-1 -2;-3 -4] := bp[-1;-3 -2]*Rmap_bm_to_am[1;2]*conj(pm_f[-4;1 2])
-    @plansor kijl[-1 -2;-3 -4] := bm[-1;-3 -2]*Rmap_bp_to_ap[1;2]*conj(mp_f[-4;1 2])
-    @plansor lijk[-1 -2;-3 -4] := bm[-1;-3 -2]*Rmap_bm_to_am[1;2]*conj(pm_f[-4;1 2])
-    @plansor jikl[-1 -2;-3 -4] := iso_pp[-1;1]*ap[2 -2;3]*τ[1 2;-3 4]*conj(pp_f[-4;4 3])
-    @plansor likj[-1 -2;-3 -4] := iso_pp[-1;1]*am[2 -2;3]*τ[1 2;-3 4]*conj(pm_f[-4;4 3])
-    @plansor jkil[-1 -2;-3 -4] := iso_mm[-1;1]*ap[2 -2;3]*τ[1 2;-3 4]*conj(mp_f[-4;4 3])
-    @plansor lkij[-1 -2;-3 -4] := iso_mm[-1;1]*am[2 -2;3]*τ[1 2;-3 4]*conj(mm_f[-4;4 3])
-    @plansor ijkl[-1 -2;-3 -4] := iso_pp[-1;1]*ap[-3 2;3]*τ[2 1;4 -2]*conj(pp_f[-4;3 4])
-    @plansor ljki[-1 -2;-3 -4] := iso_mm[-1;1]*ap[-3 2;3]*τ[2 1;4 -2]*conj(pm_f[-4;3 4])
-    @plansor ikjl[-1 -2;-3 -4] := iso_pp[-1;1]*am[-3 2;3]*τ[2 1;4 -2]*conj(mp_f[-4;3 4])
-    @plansor lkji[-1 -2;-3 -4] := iso_mm[-1;1]*am[-3 2;3]*τ[2 1;4 -2]*conj(mm_f[-4;3 4])
+    @plansor pjiR[-1 -2;-3 -4] := mp_f[-1;1 2] * Lmap_ap_to_bp[2;1] * ap[-3 -2;-4]
+    @plansor pijR[-1 -2;-3 -4] := pm_f[-1;1 2] * Lmap_am_to_bm[2;1] * ap[-3 -2;-4]
+    @plansor Rjim[-1 -2;-3 -4] := mp_f[-1;1 2] * Lmap_ap_to_bp[2;1] * am[-3 -2;-4]
+    @plansor Rijm[-1 -2;-3 -4] := pm_f[-1;1 2] * Lmap_am_to_bm[2;1] * am[-3 -2;-4]
+    @plansor jimR[-1 -2;-3 -4] := pp_f[-1;1 2] * τ[3 2;-4 -2] * bm[1;-3 3]
+    @plansor ijRm[-1 -2;-3 -4] := permute(pp_f, ((1,), (3, 2)))[-1;1 2] * τ[1 3;-3 -4] * bm[2;3 -2]
+    @plansor ijmR[-1 -2;-3 -4] := permute(pp_f, ((1,), (3, 2)))[-1;1 2] * τ[3 2;-4 -2] * bm[1;-3 3]
+    @plansor jiRm[-1 -2;-3 -4] := pp_f[-1;1 2] * τ[1 3;-3 -4] * bm[2;3 -2]
+    @plansor jpiR[-1 -2;-3 -4] := mp_f[-1;1 2] * τ[3 2;-4 -2] * bp[1;-3 3]
+    @plansor ipjR[-1 -2;-3 -4] := permute(pm_f, ((1,), (3, 2)))[-1;1 2] * τ[3 2;-4 -2] * bp[1;-3 3]
+    @plansor jRim[-1 -2;-3 -4] := mp_f[-1;1 2] * τ[1 3;-3 -4] * bm[2;3 -2]
+    @plansor iRjm[-1 -2;-3 -4] := permute(pm_f, ((1,), (3, 2)))[-1;1 2] * τ[1 3;-3 -4] * bm[2;3 -2]
+    @plansor Rpji[-1 -2;-3 -4] := mm_f[-1;1 2] * τ[1 3;-3 -4] * bp[2;3 -2]
+    @plansor pRij[-1 -2;-3 -4] := permute(mm_f, ((1,), (3, 2)))[-1;1 2] * τ[3 2;-4 -2] * bp[1;-3 3]
+    @plansor Rpij[-1 -2;-3 -4] := permute(mm_f, ((1,), (3, 2)))[-1;1 2] * τ[1 3;-3 -4] * bp[2;3 -2]
+    @plansor pRji[-1 -2;-3 -4] := mm_f[-1;1 2] * τ[3 2;-4 -2] * bp[1;-3 3]
+    @plansor kjil[-1 -2;-3 -4] := bp[-1;-3 -2] * Rmap_bp_to_ap[1;2] * conj(mp_f[-4;1 2])
+    @plansor ljik[-1 -2;-3 -4] := bp[-1;-3 -2] * Rmap_bm_to_am[1;2] * conj(pm_f[-4;1 2])
+    @plansor kijl[-1 -2;-3 -4] := bm[-1;-3 -2] * Rmap_bp_to_ap[1;2] * conj(mp_f[-4;1 2])
+    @plansor lijk[-1 -2;-3 -4] := bm[-1;-3 -2] * Rmap_bm_to_am[1;2] * conj(pm_f[-4;1 2])
+    @plansor jikl[-1 -2;-3 -4] := iso_pp[-1;1] * ap[2 -2;3] * τ[1 2;-3 4] * conj(pp_f[-4;4 3])
+    @plansor likj[-1 -2;-3 -4] := iso_pp[-1;1] * am[2 -2;3] * τ[1 2;-3 4] * conj(pm_f[-4;4 3])
+    @plansor jkil[-1 -2;-3 -4] := iso_mm[-1;1] * ap[2 -2;3] * τ[1 2;-3 4] * conj(mp_f[-4;4 3])
+    @plansor lkij[-1 -2;-3 -4] := iso_mm[-1;1] * am[2 -2;3] * τ[1 2;-3 4] * conj(mm_f[-4;4 3])
+    @plansor ijkl[-1 -2;-3 -4] := iso_pp[-1;1] * ap[-3 2;3] * τ[2 1;4 -2] * conj(pp_f[-4;3 4])
+    @plansor ljki[-1 -2;-3 -4] := iso_mm[-1;1] * ap[-3 2;3] * τ[2 1;4 -2] * conj(pm_f[-4;3 4])
+    @plansor ikjl[-1 -2;-3 -4] := iso_pp[-1;1] * am[-3 2;3] * τ[2 1;4 -2] * conj(mp_f[-4;3 4])
+    @plansor lkji[-1 -2;-3 -4] := iso_mm[-1;1] * am[-3 2;3] * τ[2 1;4 -2] * conj(mm_f[-4;3 4])
 
-    
-    for i in 1:basis_size,j in i+1:basis_size,k in j+1:half_basis_size,l in k+1:basis_size
+
+    for i in 1:basis_size,j in (i + 1):basis_size,k in (j + 1):half_basis_size,l in (k + 1):basis_size
         # p j i R
         # j p R i
-        hamdat[k,indmap_2L[2,i,1,j],indmap_1R[2,l]] += (V[j,k,l,i]+V[k,j,i,l])*pjiR
+        hamdat[k, indmap_2L[2, i, 1, j], indmap_1R[2, l]] += (V[j, k, l, i] + V[k, j, i, l]) * pjiR
         # p i j R
         # i p R j
-        hamdat[k,indmap_2L[1,i,2,j],indmap_1R[2,l]] += (V[i,k,l,j]+V[k,i,j,l])*pijR
-        
-        
+        hamdat[k, indmap_2L[1, i, 2, j], indmap_1R[2, l]] += (V[i, k, l, j] + V[k, i, j, l]) * pijR
+
+
         # R j i m
         # j R m i
-        hamdat[k,indmap_2L[2,i,1,j],indmap_1R[1,l]] += (V[j,l,k,i]+V[l,j,i,k])*Rjim        
+        hamdat[k, indmap_2L[2, i, 1, j], indmap_1R[1, l]] += (V[j, l, k, i] + V[l, j, i, k]) * Rjim
         # R i j m
         # i R m j
-        hamdat[k,indmap_2L[1,i,2,j],indmap_1R[1,l]] += (V[i,l,k,j]+V[l,i,j,k])*Rijm        
-        
-        
-    
+        hamdat[k, indmap_2L[1, i, 2, j], indmap_1R[1, l]] += (V[i, l, k, j] + V[l, i, j, k]) * Rijm
+
+
         # j i m R
-        hamdat[k,indmap_2L[1,i,1,j],indmap_1R[2,l]] += V[j,i,k,l]*jimR
+        hamdat[k, indmap_2L[1, i, 1, j], indmap_1R[2, l]] += V[j, i, k, l] * jimR
         # i j R m
-        hamdat[k,indmap_2L[1,i,1,j],indmap_1R[2,l]] += V[i,j,l,k]*ijRm
+        hamdat[k, indmap_2L[1, i, 1, j], indmap_1R[2, l]] += V[i, j, l, k] * ijRm
 
         # i j m R
-        hamdat[k,indmap_2L[1,i,1,j],indmap_1R[2,l]] += V[i,j,k,l]*ijmR
+        hamdat[k, indmap_2L[1, i, 1, j], indmap_1R[2, l]] += V[i, j, k, l] * ijmR
         # j i R m
-        hamdat[k,indmap_2L[1,i,1,j],indmap_1R[2,l]] += V[j,i,l,k]*jiRm
+        hamdat[k, indmap_2L[1, i, 1, j], indmap_1R[2, l]] += V[j, i, l, k] * jiRm
 
         # j p i R
         # p j R i
-        hamdat[k,indmap_2L[2,i,1,j],indmap_1R[2,l]] += (V[k,j,l,i]+V[j,k,i,l])*jpiR
+        hamdat[k, indmap_2L[2, i, 1, j], indmap_1R[2, l]] += (V[k, j, l, i] + V[j, k, i, l]) * jpiR
 
         # i p j R
         # p i R j
-        hamdat[k,indmap_2L[1,i,2,j],indmap_1R[2,l]] += (V[k,i,l,j]+V[i,k,j,l])*ipjR
+        hamdat[k, indmap_2L[1, i, 2, j], indmap_1R[2, l]] += (V[k, i, l, j] + V[i, k, j, l]) * ipjR
 
         # j R i m
         # R j m i
-        hamdat[k,indmap_2L[2,i,1,j],indmap_1R[1,l]] += (V[l,j,k,i]+V[j,l,i,k])*jRim
+        hamdat[k, indmap_2L[2, i, 1, j], indmap_1R[1, l]] += (V[l, j, k, i] + V[j, l, i, k]) * jRim
 
         # i R j m
         # R i m j
-        hamdat[k,indmap_2L[1,i,2,j],indmap_1R[1,l]] += (V[l,i,k,j]+V[i,l,j,k])*iRjm
-        
+        hamdat[k, indmap_2L[1, i, 2, j], indmap_1R[1, l]] += (V[l, i, k, j] + V[i, l, j, k]) * iRjm
+
         # R p j i
-        hamdat[k,indmap_2L[2,i,2,j],indmap_1R[1,l]] += V[l,k,j,i]*Rpji
+        hamdat[k, indmap_2L[2, i, 2, j], indmap_1R[1, l]] += V[l, k, j, i] * Rpji
         # p R i j
-        hamdat[k,indmap_2L[2,i,2,j],indmap_1R[1,l]] += V[k,l,i,j]*pRij
+        hamdat[k, indmap_2L[2, i, 2, j], indmap_1R[1, l]] += V[k, l, i, j] * pRij
 
         # R p i j
-        hamdat[k,indmap_2L[2,i,2,j],indmap_1R[1,l]] += V[l,k,i,j]*Rpij
+        hamdat[k, indmap_2L[2, i, 2, j], indmap_1R[1, l]] += V[l, k, i, j] * Rpij
         # p R j i
-        hamdat[k,indmap_2L[2,i,2,j],indmap_1R[1,l]] += V[k,l,j,i]*pRji
+        hamdat[k, indmap_2L[2, i, 2, j], indmap_1R[1, l]] += V[k, l, j, i] * pRji
     end
-    
-    
-    for i in 1:basis_size,j in i+1:basis_size,k in j+1:basis_size,l in k+1:basis_size
-        j >= half_basis_size || continue;
 
-        hamdat[j,indmap_1L[2,i],indmap_2R[1,k,2,l]] += (V[k,j,i,l]+V[j,k,l,i])*kjil
-        hamdat[j,indmap_1L[2,i],indmap_2R[2,k,1,l]] += (V[l,j,i,k]+V[j,l,k,i])*ljik
-        hamdat[j,indmap_1L[1,i],indmap_2R[1,k,2,l]] += (V[k,i,j,l]+V[i,k,l,j])*kijl
 
-        hamdat[j,indmap_1L[1,i],indmap_2R[2,k,1,l]] += (V[l,i,j,k]+V[i,l,k,j])*lijk
-        hamdat[j,indmap_1L[1,i],indmap_2R[2,k,2,l]] += (V[j,i,k,l]+V[i,j,l,k])*jikl
-        hamdat[j,indmap_1L[1,i],indmap_2R[2,k,1,l]] += (V[l,i,k,j]+V[i,l,j,k])*likj
-        hamdat[j,indmap_1L[2,i],indmap_2R[1,k,2,l]] += (V[j,k,i,l]+V[k,j,l,i])*jkil
-        hamdat[j,indmap_1L[2,i],indmap_2R[1,k,1,l]] += (V[l,k,i,j]+V[k,l,j,i])*lkij;
-        hamdat[j,indmap_1L[1,i],indmap_2R[2,k,2,l]] += (V[i,j,k,l]+V[j,i,l,k])*ijkl;
-        hamdat[j,indmap_1L[2,i],indmap_2R[2,k,1,l]] += (V[l,j,k,i]+V[j,l,i,k])*ljki
-        hamdat[j,indmap_1L[1,i],indmap_2R[1,k,2,l]] += (V[i,k,j,l]+V[k,i,l,j])*ikjl
-        hamdat[j,indmap_1L[2,i],indmap_2R[1,k,1,l]] += (V[l,k,j,i]+V[k,l,i,j])*lkji
+    for i in 1:basis_size,j in (i + 1):basis_size,k in (j + 1):basis_size,l in (k + 1):basis_size
+        j >= half_basis_size || continue
+
+        hamdat[j, indmap_1L[2, i], indmap_2R[1, k, 2, l]] += (V[k, j, i, l] + V[j, k, l, i]) * kjil
+        hamdat[j, indmap_1L[2, i], indmap_2R[2, k, 1, l]] += (V[l, j, i, k] + V[j, l, k, i]) * ljik
+        hamdat[j, indmap_1L[1, i], indmap_2R[1, k, 2, l]] += (V[k, i, j, l] + V[i, k, l, j]) * kijl
+
+        hamdat[j, indmap_1L[1, i], indmap_2R[2, k, 1, l]] += (V[l, i, j, k] + V[i, l, k, j]) * lijk
+        hamdat[j, indmap_1L[1, i], indmap_2R[2, k, 2, l]] += (V[j, i, k, l] + V[i, j, l, k]) * jikl
+        hamdat[j, indmap_1L[1, i], indmap_2R[2, k, 1, l]] += (V[l, i, k, j] + V[i, l, j, k]) * likj
+        hamdat[j, indmap_1L[2, i], indmap_2R[1, k, 2, l]] += (V[j, k, i, l] + V[k, j, l, i]) * jkil
+        hamdat[j, indmap_1L[2, i], indmap_2R[1, k, 1, l]] += (V[l, k, i, j] + V[k, l, j, i]) * lkij
+        hamdat[j, indmap_1L[1, i], indmap_2R[2, k, 2, l]] += (V[i, j, k, l] + V[j, i, l, k]) * ijkl
+        hamdat[j, indmap_1L[2, i], indmap_2R[2, k, 1, l]] += (V[l, j, k, i] + V[j, l, i, k]) * ljki
+        hamdat[j, indmap_1L[1, i], indmap_2R[1, k, 2, l]] += (V[i, k, j, l] + V[k, i, l, j]) * ikjl
+        hamdat[j, indmap_1L[2, i], indmap_2R[1, k, 1, l]] += (V[l, k, j, i] + V[k, l, i, j]) * lkji
     end
-    
-    @plansor kjil[-1 -2;-3 -4] := mp_f[-1;1 2]*Lmap_ap_to_bp[2;1]*ai[-2;-3]*Rmap_bp_to_ap[3;4]*conj(mp_f[-4;3 4])
-    @plansor ljik[-1 -2;-3 -4] := mp_f[-1;1 2]*Lmap_ap_to_bp[2;1]*ai[-2;-3]*Rmap_bm_to_am[3;4]*conj(pm_f[-4;3 4])
-    @plansor kijl[-1 -2;-3 -4] := pm_f[-1;1 2]*Lmap_am_to_bm[2;1]*ai[-2;-3]*Rmap_bp_to_ap[3;4]*conj(mp_f[-4;3 4])
-    @plansor lijk[-1 -2;-3 -4] := pm_f[-1;1 2]*Lmap_am_to_bm[2;1]*ai[-2;-3]*Rmap_bm_to_am[3;4]*conj(pm_f[-4;3 4])
-    @plansor jikl[-1 -2;-3 -4] := pp_f[-1;1 2]*ai[3;-3]*τ[3 1;4 5]*τ[5 2;6 -2]*conj(pp_f[-4;4 6])
-    @plansor likj[-1 -2;-3 -4] := pm_f[-1;1 2]*ai[3;-3]*τ[3 1;4 5]*τ[5 2;6 -2]*conj(pm_f[-4;4 6])
-    @plansor jkil[-1 -2;-3 -4] := mp_f[-1;1 2]*ai[3;-3]*τ[3 1;4 5]*τ[5 2;6 -2]*conj(mp_f[-4;4 6])
-    @plansor lkij[-1 -2;-3 -4] := mm_f[-1;1 2]*ai[3;-3]*τ[3 1;4 5]*τ[5 2;6 -2]*conj(mm_f[-4;4 6])
-    @plansor ijkl[-1 -2;-3 -4] := pp_f[-1;7 8]*τ[7 8;1 2]*ai[3;-3]*τ[3 1;4 5]*τ[5 2;6 -2]*conj(pp_f[-4;4 6])
-    @plansor ljki[-1 -2;-3 -4] := mp_f[-1;7 8]*τ[7 8;1 2]*ai[3;-3]*τ[3 1;4 5]*τ[5 2;6 -2]*conj(pm_f[-4;4 6])
-    @plansor ikjl[-1 -2;-3 -4] := pm_f[-1;7 8]*τ[7 8;1 2]*ai[3;-3]*τ[3 1;4 5]*τ[5 2;6 -2]*conj(mp_f[-4;4 6])
-    @plansor lkji[-1 -2;-3 -4] := mm_f[-1;7 8]*τ[7 8;1 2]*ai[3;-3]*τ[3 1;4 5]*τ[5 2;6 -2]*conj(mm_f[-4;4 6])
-        
-    for i in 1:half_basis_size-1,j in i+1:half_basis_size-1,k in half_basis_size+1:basis_size,l in k+1:basis_size
-        
+
+    @plansor kjil[-1 -2;-3 -4] := mp_f[-1;1 2] * Lmap_ap_to_bp[2;1] * ai[-2;-3] * Rmap_bp_to_ap[3;4] * conj(mp_f[-4;3 4])
+    @plansor ljik[-1 -2;-3 -4] := mp_f[-1;1 2] * Lmap_ap_to_bp[2;1] * ai[-2;-3] * Rmap_bm_to_am[3;4] * conj(pm_f[-4;3 4])
+    @plansor kijl[-1 -2;-3 -4] := pm_f[-1;1 2] * Lmap_am_to_bm[2;1] * ai[-2;-3] * Rmap_bp_to_ap[3;4] * conj(mp_f[-4;3 4])
+    @plansor lijk[-1 -2;-3 -4] := pm_f[-1;1 2] * Lmap_am_to_bm[2;1] * ai[-2;-3] * Rmap_bm_to_am[3;4] * conj(pm_f[-4;3 4])
+    @plansor jikl[-1 -2;-3 -4] := pp_f[-1;1 2] * ai[3;-3] * τ[3 1;4 5] * τ[5 2;6 -2] * conj(pp_f[-4;4 6])
+    @plansor likj[-1 -2;-3 -4] := pm_f[-1;1 2] * ai[3;-3] * τ[3 1;4 5] * τ[5 2;6 -2] * conj(pm_f[-4;4 6])
+    @plansor jkil[-1 -2;-3 -4] := mp_f[-1;1 2] * ai[3;-3] * τ[3 1;4 5] * τ[5 2;6 -2] * conj(mp_f[-4;4 6])
+    @plansor lkij[-1 -2;-3 -4] := mm_f[-1;1 2] * ai[3;-3] * τ[3 1;4 5] * τ[5 2;6 -2] * conj(mm_f[-4;4 6])
+    @plansor ijkl[-1 -2;-3 -4] := pp_f[-1;7 8] * τ[7 8;1 2] * ai[3;-3] * τ[3 1;4 5] * τ[5 2;6 -2] * conj(pp_f[-4;4 6])
+    @plansor ljki[-1 -2;-3 -4] := mp_f[-1;7 8] * τ[7 8;1 2] * ai[3;-3] * τ[3 1;4 5] * τ[5 2;6 -2] * conj(pm_f[-4;4 6])
+    @plansor ikjl[-1 -2;-3 -4] := pm_f[-1;7 8] * τ[7 8;1 2] * ai[3;-3] * τ[3 1;4 5] * τ[5 2;6 -2] * conj(mp_f[-4;4 6])
+    @plansor lkji[-1 -2;-3 -4] := mm_f[-1;7 8] * τ[7 8;1 2] * ai[3;-3] * τ[3 1;4 5] * τ[5 2;6 -2] * conj(mm_f[-4;4 6])
+
+    for i in 1:(half_basis_size - 1),j in (i + 1):(half_basis_size - 1),k in (half_basis_size + 1):basis_size,l in (k + 1):basis_size
+
         # k j i l
         # j k l i
-        hamdat[half_basis_size,indmap_2L[2,i,1,j],indmap_2R[1,k,2,l]] += (V[k,j,i,l]+V[j,k,l,i])*kjil
-        
+        hamdat[half_basis_size, indmap_2L[2, i, 1, j], indmap_2R[1, k, 2, l]] += (V[k, j, i, l] + V[j, k, l, i]) * kjil
+
         # l j i k
         # j l k i
-        hamdat[half_basis_size,indmap_2L[2,i,1,j],indmap_2R[2,k,1,l]] += (V[l,j,i,k]+V[j,l,k,i])*ljik
-        
+        hamdat[half_basis_size, indmap_2L[2, i, 1, j], indmap_2R[2, k, 1, l]] += (V[l, j, i, k] + V[j, l, k, i]) * ljik
+
         # k i j l
         # i k l j
-        hamdat[half_basis_size,indmap_2L[1,i,2,j],indmap_2R[1,k,2,l]] += (V[k,i,j,l]+V[i,k,l,j])*kijl
+        hamdat[half_basis_size, indmap_2L[1, i, 2, j], indmap_2R[1, k, 2, l]] += (V[k, i, j, l] + V[i, k, l, j]) * kijl
 
         # l i j k
         # i l k j
-        hamdat[half_basis_size,indmap_2L[1,i,2,j],indmap_2R[2,k,1,l]] += (V[l,i,j,k]+V[i,l,k,j])*lijk
-        
+        hamdat[half_basis_size, indmap_2L[1, i, 2, j], indmap_2R[2, k, 1, l]] += (V[l, i, j, k] + V[i, l, k, j]) * lijk
+
         # j i k l
         # i j l k
-        hamdat[half_basis_size,indmap_2L[1,i,1,j],indmap_2R[2,k,2,l]] += (V[j,i,k,l]+V[i,j,l,k])*jikl
-        
+        hamdat[half_basis_size, indmap_2L[1, i, 1, j], indmap_2R[2, k, 2, l]] += (V[j, i, k, l] + V[i, j, l, k]) * jikl
+
         # l i k j
         # i l j k
-        hamdat[half_basis_size,indmap_2L[1,i,2,j],indmap_2R[2,k,1,l]] += (V[l,i,k,j]+V[i,l,j,k])*likj
+        hamdat[half_basis_size, indmap_2L[1, i, 2, j], indmap_2R[2, k, 1, l]] += (V[l, i, k, j] + V[i, l, j, k]) * likj
 
         # j k i l
         # k j l i
-        hamdat[half_basis_size,indmap_2L[2,i,1,j],indmap_2R[1,k,2,l]] += (V[j,k,i,l]+V[k,j,l,i])*jkil
+        hamdat[half_basis_size, indmap_2L[2, i, 1, j], indmap_2R[1, k, 2, l]] += (V[j, k, i, l] + V[k, j, l, i]) * jkil
 
         # l k i j
         # k l j i
-        hamdat[half_basis_size,indmap_2L[2,i,2,j],indmap_2R[1,k,1,l]] += (V[l,k,i,j]+V[k,l,j,i])*lkij
+        hamdat[half_basis_size, indmap_2L[2, i, 2, j], indmap_2R[1, k, 1, l]] += (V[l, k, i, j] + V[k, l, j, i]) * lkij
 
         # i j k l
         # j i l k
-        hamdat[half_basis_size,indmap_2L[1,i,1,j],indmap_2R[2,k,2,l]] += (V[i,j,k,l]+V[j,i,l,k])*ijkl
-        
+        hamdat[half_basis_size, indmap_2L[1, i, 1, j], indmap_2R[2, k, 2, l]] += (V[i, j, k, l] + V[j, i, l, k]) * ijkl
+
         # l j k i
         # j l i k
-        hamdat[half_basis_size,indmap_2L[2,i,1,j],indmap_2R[2,k,1,l]] += (V[l,j,k,i]+V[j,l,i,k])*ljki
-        
+        hamdat[half_basis_size, indmap_2L[2, i, 1, j], indmap_2R[2, k, 1, l]] += (V[l, j, k, i] + V[j, l, i, k]) * ljki
+
         # i k j l
         # k i l j
-        hamdat[half_basis_size,indmap_2L[1,i,2,j],indmap_2R[1,k,2,l]] += (V[i,k,j,l]+V[k,i,l,j])*ikjl
-        
+        hamdat[half_basis_size, indmap_2L[1, i, 2, j], indmap_2R[1, k, 2, l]] += (V[i, k, j, l] + V[k, i, l, j]) * ikjl
+
         # l k j i
         # k l i j
-        hamdat[half_basis_size,indmap_2L[2,i,2,j],indmap_2R[1,k,1,l]] += (V[l,k,j,i]+V[k,l,i,j])*lkji
-        
+        hamdat[half_basis_size, indmap_2L[2, i, 2, j], indmap_2R[1, k, 1, l]] += (V[l, k, j, i] + V[k, l, i, j]) * lkji
+
     end
-    
-    
-    map!(x->x == EmptyVal() ? Elt(0) : x,hamdat,hamdat);
-    th = MPOHamiltonian(convert(Array{Union{Elt,typeof(ut_ap)},3},hamdat));
+
+
+    map!(x -> x == EmptyVal() ? Elt(0) : x, hamdat, hamdat)
+    th = MPOHamiltonian(convert(Array{Union{Elt, typeof(ut_ap)}, 3}, hamdat))
 
     @show half_basis_size
-    th+fill(Elt(E0)/basis_size,basis_size),
+    return th + fill(Elt(E0) / basis_size, basis_size),
         (indmap_1L, indmap_1R, indmap_2L, indmap_2R)
 end
-
-

--- a/src/models/quantum_chemistry.jl
+++ b/src/models/quantum_chemistry.jl
@@ -806,8 +806,10 @@ function mapped_quantum_chemistry_hamiltonian(E0, K, V, Elt = ComplexF64)
 
 
     map!(x -> x == EmptyVal() ? Elt(0) : x, hamdat, hamdat)
-    # TODO constructor errors: no signature
-    th = MPOHamiltonian(convert(Array{Union{Elt, typeof(ut_ap)}, 3}, hamdat))
+    v = convert.(Matrix{Union{Elt, typeof(ut_ap)}}, eachslice(hamdat; dims = 1))
+
+    # TODO constructor errors: edges should have single level
+    th = FiniteMPOHamiltonian(v)
 
     return th + fill(Elt(E0) / basis_size, basis_size),
         (indmap_1L, indmap_1R, indmap_2L, indmap_2R)

--- a/src/models/quantum_chemistry.jl
+++ b/src/models/quantum_chemistry.jl
@@ -44,16 +44,12 @@ function mapped_quantum_chemistry_hamiltonian(E0, K, V, Elt = ComplexF64)
         (2, 0, 0) => 1
     )
 
-    ap = ones(
-        Elt,
-        psp * Vect[(U1Irrep ⊠ SU2Irrep ⊠ FermionParity)]((-1, 1 // 2, 1) => 1),
-        psp
-    )
+    one_hole_space = Vect[(U1Irrep ⊠ SU2Irrep ⊠ FermionParity)]((-1, 1 // 2, 1) => 1)
+    ap = ones(Elt, psp ⊗ one_hole_space, psp)
     block(ap, U1Irrep(0) ⊠ SU2Irrep(0) ⊠ FermionParity(0)) .*= -sqrt(2)
     block(ap, U1Irrep(1) ⊠ SU2Irrep(1 // 2) ⊠ FermionParity(1)) .*= 1
 
-
-    bm = ones(Elt, psp, Vect[(U1Irrep ⊠ SU2Irrep ⊠ FermionParity)]((-1, 1 // 2, 1) => 1) * psp)
+    bm = ones(Elt, psp, one_hole_space ⊗ psp)
     block(bm, U1Irrep(0) ⊠ SU2Irrep(0) ⊠ FermionParity(0)) .*= sqrt(2)
     block(bm, U1Irrep(1) ⊠ SU2Irrep(1 // 2) ⊠ FermionParity(1)) .*= -1
 
@@ -120,7 +116,7 @@ function mapped_quantum_chemistry_hamiltonian(E0, K, V, Elt = ComplexF64)
         indmap_2R[pm1, end - j + 1, pm2, end - i + 1] = cnt
     end
 
-    hamdat = convert(Array{Any, 3}, fill(EmptyVal(), basis_size, cnt + 1, cnt + 1)) #Array{Any,3}(missing,basis_size,cnt+2,cnt+2);
+    hamdat = convert(Array{Any, 3}, fill(EmptyVal(), basis_size, cnt + 1, cnt + 1))
     hamdat[:, 1, 1] .+= Elt(1)
     hamdat[:, end, end] .+= Elt(1)
 

--- a/test/quantumchemistry.jl
+++ b/test/quantumchemistry.jl
@@ -1,0 +1,22 @@
+using Test: @testset
+
+using MPSKitModels: quantum_chemistry_hamiltonian
+
+## Setup
+# H2 molecule with sto-3g basis and molecular orbitals from Hartree-Fock
+
+ecore = 0.7178535240637794
+hpq = [-1.2550254253591244 0.0; 0.0 -0.4732763494710688]
+hpqrs = zeros((2, 2, 2, 2))
+hpqrs[1, 1, 1, 1] = 0.6752967689354994
+hpqrs[2, 2, 1, 1] = 0.6642044392432876
+hpqrs[2, 1, 2, 1] = 0.18105207136899099
+hpqrs[1, 2, 2, 1] = 0.18105207136899099
+hpqrs[2, 1, 1, 2] = 0.18105207136899099
+hpqrs[1, 2, 1, 2] = 0.18105207136899099
+hpqrs[1, 1, 2, 2] = 0.6642044392432875
+hpqrs[2, 2, 2, 2] = 0.6981738857839888
+
+@testset "Quantum chemistry Hamiltonian" begin
+    mpo = quantum_chemistry_hamiltonian(ecore, hpq, hpqrs, Float64)
+end


### PR DESCRIPTION
I wanted to try out the quantum chemistry Hamiltonian (I know it is not state of the art as discussed in #36). I realized the constructor is not working. It seems to me there is some merge/rebase conflict in its history: some parts look outdated.

This is a work in progress to get it working again. I first tried to start from main and fix the file gradually, but I ended up being stuck with some space error (see https://github.com/ogauthe/MPSKitModels.jl/tree/quntumchemistry for the result). Here I tried a different approach: reset to d6edd824c3bfe5e9af0485288b43132fda066a83 and start from there. This commit made major changes to the file, including changing variable names. Future commits then mix old and new varname (`map_1` vs `indmap_1L`), so I believe there was a merge conflict.

I am now able to run the constructor up to the last line: constructing the MPO. Then the constructor from the raw data does not exist in current `MPSKit` and I do not know how to proceed. This should be the very last part: if I get this to work, I should be able to run a complete simulation and check the results with e.g. block2.

Error is
```julia
ERROR: LoadError: MethodError: no method matching MPSKit.MPOHamiltonian(::Array{Union{Float64, TensorMap{Float64, GradedSpace{…}, 2, 2, Vector{…}}}, 3})
```

Questions:
- are you still interested in having a quantum chemistry Hamiltonian?
- do you know what would be the correct constructor for the MPO (line 810)?